### PR TITLE
Removed unit conversion for forces, velocities and mass

### DIFF
--- a/box2dbody.cpp
+++ b/box2dbody.cpp
@@ -150,8 +150,8 @@ void Box2DBody::setAwake(bool awake)
 QPointF Box2DBody::linearVelocity() const
 {
     if (mBody)
-        return toPixels(mBody->GetLinearVelocity());
-    return toPixels(mBodyDef.linearVelocity);
+        return invertY(mBody->GetLinearVelocity());
+    return invertY(mBodyDef.linearVelocity);
 }
 
 void Box2DBody::setLinearVelocity(const QPointF &velocity)
@@ -159,7 +159,7 @@ void Box2DBody::setLinearVelocity(const QPointF &velocity)
     if (linearVelocity() == velocity)
         return;
 
-    mBodyDef.linearVelocity = toMeters(velocity);
+    mBodyDef.linearVelocity = invertY(velocity);
     if (mBody)
         mBody->SetLinearVelocity(mBodyDef.linearVelocity);
 
@@ -311,10 +311,8 @@ void Box2DBody::onRotationChanged()
 void Box2DBody::applyLinearImpulse(const QPointF &impulse,
                                    const QPointF &point)
 {
-    if (mBody) {
-        mBody->ApplyLinearImpulse(toMeters(impulse),
-                                  toMeters(point), true);
-    }
+    if (mBody)
+        mBody->ApplyLinearImpulse(invertY(impulse), toMeters(point), true);
 }
 
 void Box2DBody::applyTorque(qreal torque)
@@ -332,21 +330,19 @@ QPointF Box2DBody::getWorldCenter() const
 
 void Box2DBody::applyForce(const QPointF &force, const QPointF &point)
 {
-    if (mBody) {
-        mBody->ApplyForce(toMeters(force),
-                          toMeters(point), true);
-    }
+    if (mBody)
+        mBody->ApplyForce(invertY(force), toMeters(point), true);
 }
 
 void Box2DBody::applyForceToCenter(const QPointF &force)
 {
     if (mBody)
-        mBody->ApplyForceToCenter(toMeters(force), true);
+        mBody->ApplyForceToCenter(invertY(force), true);
 }
 
 float Box2DBody::getMass() const
 {
-    return mBody ? toPixels(toPixels(mBody->GetMass())) : 0.0;
+    return mBody ? mBody->GetMass() : 0.0;
 }
 
 void Box2DBody::resetMassData()
@@ -362,10 +358,10 @@ float Box2DBody::getInertia() const
 
 QPointF Box2DBody::getLinearVelocityFromWorldPoint(const QPointF &point) const
 {
-    return toPixels(mBody->GetLinearVelocityFromWorldPoint(toMeters(point)));
+    return invertY(mBody->GetLinearVelocityFromWorldPoint(toMeters(point)));
 }
 
 QPointF Box2DBody::getLinearVelocityFromLocalPoint(const QPointF &point) const
 {
-    return toPixels(mBody->GetLinearVelocityFromLocalPoint(toMeters(point)));
+    return invertY(mBody->GetLinearVelocityFromLocalPoint(toMeters(point)));
 }

--- a/box2dcontact.cpp
+++ b/box2dcontact.cpp
@@ -112,10 +112,10 @@ void Box2DContact::resetRestitution()
 
 qreal Box2DContact::getTangentSpeed() const
 {
-    return toPixels(mContact->GetTangentSpeed());
+    return mContact->GetTangentSpeed();
 }
 
 void Box2DContact::setTangentSpeed(qreal speed)
 {
-    mContact->SetTangentSpeed(toMeters(speed));
+    mContact->SetTangentSpeed(speed);
 }

--- a/box2ddistancejoint.cpp
+++ b/box2ddistancejoint.cpp
@@ -111,7 +111,7 @@ b2Joint *Box2DDistanceJoint::createJoint()
 QPointF Box2DDistanceJoint::getReactionForce(float32 inv_dt) const
 {
     if (distanceJoint())
-        return toPixels(distanceJoint()->GetReactionForce(inv_dt));
+        return invertY(distanceJoint()->GetReactionForce(inv_dt));
     return QPointF();
 }
 

--- a/box2dfrictionjoint.cpp
+++ b/box2dfrictionjoint.cpp
@@ -106,7 +106,7 @@ b2Joint *Box2DFrictionJoint::createJoint()
 QPointF Box2DFrictionJoint::getReactionForce(float32 inv_dt) const
 {
     if (frictionJoint())
-        return toPixels(frictionJoint()->GetReactionForce(inv_dt));
+        return invertY(frictionJoint()->GetReactionForce(inv_dt));
     return QPointF();
 }
 

--- a/box2dmousejoint.cpp
+++ b/box2dmousejoint.cpp
@@ -91,7 +91,7 @@ b2Joint *Box2DMouseJoint::createJoint()
 QPointF Box2DMouseJoint::getReactionForce(float32 inv_dt) const
 {
     if (mouseJoint())
-        return toPixels(mouseJoint()->GetReactionForce(inv_dt));
+        return invertY(mouseJoint()->GetReactionForce(inv_dt));
     return QPointF();
 }
 

--- a/box2dprismaticjoint.cpp
+++ b/box2dprismaticjoint.cpp
@@ -127,7 +127,7 @@ QPointF Box2DPrismaticJoint::axis() const
 
 void Box2DPrismaticJoint::setAxis(const QPointF &axis)
 {
-    mPrismaticJointDef.localAxisA = toMeters(axis);
+    mPrismaticJointDef.localAxisA = invertY(axis);
     mPrismaticJointDef.localAxisA.Normalize();
     emit axisChanged();
 }

--- a/box2dpulleyjoint.cpp
+++ b/box2dpulleyjoint.cpp
@@ -145,7 +145,7 @@ float Box2DPulleyJoint::getCurrentLengthB() const
 QPointF Box2DPulleyJoint::getReactionForce(float32 inv_dt) const
 {
     if (pulleyJoint())
-        return toPixels(pulleyJoint()->GetReactionForce(inv_dt));
+        return invertY(pulleyJoint()->GetReactionForce(inv_dt));
     return QPointF();
 }
 

--- a/box2dropejoint.cpp
+++ b/box2dropejoint.cpp
@@ -81,7 +81,7 @@ b2Joint *Box2DRopeJoint::createJoint()
 QPointF Box2DRopeJoint::getReactionForce(float32 inv_dt) const
 {
     if (ropeJoint())
-        return toPixels(ropeJoint()->GetReactionForce(inv_dt));
+        return invertY(ropeJoint()->GetReactionForce(inv_dt));
     return QPointF();
 }
 

--- a/box2dwheeljoint.cpp
+++ b/box2dwheeljoint.cpp
@@ -127,7 +127,7 @@ QPointF Box2DWheelJoint::localAxisA() const
 
 void Box2DWheelJoint::setLocalAxisA(const QPointF &localAxisA)
 {
-    mWheelJointDef.localAnchorB = toMeters(localAxisA);
+    mWheelJointDef.localAxisA = toMeters(localAxisA);
     mAnchorsAuto = false;
     emit localAxisAChanged();
 }
@@ -154,14 +154,14 @@ float Box2DWheelJoint::getJointTranslation() const
 float Box2DWheelJoint::getJointSpeed() const
 {
     if (wheelJoint())
-        return toPixels(wheelJoint()->GetJointSpeed());
+        return wheelJoint()->GetJointSpeed();
     return 0;
 }
 
 QPointF Box2DWheelJoint::getReactionForce(float32 inv_dt) const
 {
     if (wheelJoint())
-        return toPixels(wheelJoint()->GetReactionForce(inv_dt));
+        return invertY(wheelJoint()->GetReactionForce(inv_dt));
     return QPointF();
 }
 

--- a/box2dworld.h
+++ b/box2dworld.h
@@ -181,6 +181,22 @@ inline b2World *Box2DWorld::world() const
 
 
 /**
+ * Inverts the y-axis as required for forces and velocities.
+ */
+inline QPointF invertY(const b2Vec2 &vec)
+{
+    return QPointF(vec.x, -vec.y);
+}
+
+/**
+ * Inverts the y-axis as required for forces and velocities.
+ */
+inline b2Vec2 invertY(const QPointF &vec)
+{
+    return b2Vec2(vec.x(), -vec.y());
+}
+
+/**
  * Converts lengths from Box2D to QML units.
  */
 inline float toPixels(float length)

--- a/examples/mouse/main.qml
+++ b/examples/mouse/main.qml
@@ -115,7 +115,7 @@ Rectangle {
                     anchors.fill: parent
                     propagateComposedEvents: true
                     onPressed: {
-                        mouseJoint.maxForce = parent.getMass();
+                        mouseJoint.maxForce = parent.getMass() * 500;
                         mouseJoint.bodyB = parent
                         mouse.accepted = false
                     }


### PR DESCRIPTION
Forces will stay in Newton, velocities in M/s and mass in kg. Only positions and sizes will be affected by the pixelsPerMeter ratio.

I did not test all examples yet, but adjusted at least the 'mouse' example.

Resolves part of #28.
