### PR TITLE
Removed a source from the static pri that has been removed from the tree

### DIFF
--- a/box2d-static.pri
+++ b/box2d-static.pri
@@ -20,7 +20,7 @@ include(Box2D/box2d.pri)
 
 SOURCES += $$PWD/box2dplugin.cpp \
     $$PWD/box2dworld.cpp \
-	$$PWD/box2dcontact.cpp \
+    $$PWD/box2dcontact.cpp \
     $$PWD/box2dbody.cpp \
     $$PWD/box2dfixture.cpp \
     $$PWD/box2ddebugdraw.cpp \
@@ -28,7 +28,6 @@ SOURCES += $$PWD/box2dplugin.cpp \
     $$PWD/box2drevolutejoint.cpp \
     $$PWD/box2ddistancejoint.cpp \
     $$PWD/box2dprismaticjoint.cpp \
-    $$PWD/box2ddestructionlistener.cpp \
     $$PWD/box2dmotorjoint.cpp \
     $$PWD/box2dweldjoint.cpp \
     $$PWD/box2dpulleyjoint.cpp \
@@ -43,7 +42,7 @@ SOURCES += $$PWD/box2dplugin.cpp \
 HEADERS += \
     $$PWD/box2dplugin.h \
     $$PWD/box2dworld.h \
-	$$PWD/box2dcontact.h \
+    $$PWD/box2dcontact.h \
     $$PWD/box2dbody.h \
     $$PWD/box2dfixture.h \
     $$PWD/box2ddebugdraw.h \
@@ -51,7 +50,6 @@ HEADERS += \
     $$PWD/box2drevolutejoint.h \
     $$PWD/box2ddistancejoint.h \
     $$PWD/box2dprismaticjoint.h \
-    $$PWD/box2ddestructionlistener.h \
     $$PWD/box2dmotorjoint.h \
     $$PWD/box2dweldjoint.h \
     $$PWD/box2dpulleyjoint.h \


### PR DESCRIPTION
Box2DDestructionListener was merged into Box2DWorld, but the source wasn't removed from box2d-static.pri
