### PR TITLE
Install plugin in a versioned directory to allow parallel installable versions

### DIFF
--- a/box2d.pro
+++ b/box2d.pro
@@ -13,7 +13,6 @@ INCLUDEPATH += .
 include(Box2D/box2d.pri)
 
 importPath = $$[QT_INSTALL_QML]/$$replace(TARGETPATH, \\., /).$$API_VER
-isEmpty(importPath): importPath = $$[QT_INSTALL_IMPORTS]/$$replace(TARGETPATH, \\., /).$$API_VER
 target.path = $${importPath}
 
 qmldir.path = $${importPath}


### PR DESCRIPTION
Adds API_VER and changes installation path to install in a API versioned directory, to allow for parallel installable versions.
