### PR TITLE
Add originPoint property to Body

### DIFF
--- a/box2dbody.h
+++ b/box2dbody.h
@@ -57,6 +57,7 @@ class Box2DBody : public QQuickItem
     Q_PROPERTY(float angularVelocity READ angularVelocity WRITE setAngularVelocity NOTIFY angularVelocityChanged)
     Q_PROPERTY(QQmlListProperty<Box2DFixture> fixtures READ fixtures)
     Q_PROPERTY(float gravityScale READ gravityScale WRITE setGravityScale NOTIFY gravityScaleChanged)
+    Q_PROPERTY(QPointF originPoint READ originPoint WRITE setOriginPoint NOTIFY originPointChanged)
 
 public:
     enum BodyType {
@@ -100,6 +101,9 @@ public:
 
     float gravityScale() const;
     void setGravityScale(float gravityScale);
+
+    QPointF originPoint() const;
+    void setOriginPoint(const QPointF &originPoint);
 
     QQmlListProperty<Box2DFixture> fixtures();
 
@@ -145,6 +149,7 @@ signals:
     void bodyCreated();
     void gravityScaleChanged();
     void positionChanged();
+    void originPointChanged();
 
 private:
     b2Body *mBody;
@@ -152,12 +157,17 @@ private:
     b2BodyDef mBodyDef;
     bool mSynchronizing;
     bool mInitializePending;
+    QPointF mOriginPoint;
     QList<Box2DFixture*> mFixtures;
 
     static void append_fixture(QQmlListProperty<Box2DFixture> *list,
                                Box2DFixture *fixture);
     static int count_fixture(QQmlListProperty<Box2DFixture> *list);
     static Box2DFixture *at_fixture(QQmlListProperty<Box2DFixture> *list, int index);
+    QPointF transformOrigin2Point(TransformOrigin transformOrigin);
+
+private slots:
+    void onTransformOriginChanged(TransformOrigin transformOrigin);
 };
 
 inline float Box2DBody::linearDamping() const
@@ -198,6 +208,11 @@ inline bool Box2DBody::isActive() const
 inline float Box2DBody::gravityScale() const
 {
     return mBodyDef.gravityScale;
+}
+
+inline QPointF Box2DBody::originPoint() const
+{
+    return mOriginPoint;
 }
 
 inline void Box2DBody::nullifyBody()

--- a/box2dfixture.h
+++ b/box2dfixture.h
@@ -86,6 +86,9 @@ public:
 
     Q_INVOKABLE Box2DBody *getBody() const;
 
+public slots:
+    void recreateFixture();
+
 signals:
     void densityChanged();
     void frictionChanged();
@@ -101,8 +104,7 @@ signals:
 
 protected:
     virtual b2Shape *createShape() = 0;
-    void recreateFixture();
-
+    QPointF originPoint();
     b2Fixture *mFixture;
     b2FixtureDef mFixtureDef;
     Box2DBody *mBody;

--- a/examples/originpoint/main.qml
+++ b/examples/originpoint/main.qml
@@ -1,0 +1,249 @@
+import QtQuick 2.2
+import Box2D 1.1
+
+Rectangle {
+    width: 800
+    height: 600
+    color: "#555"
+
+    World {
+        id: world
+        anchors.fill: parent
+
+        Body {
+            id: bodyBox
+            x: 50
+            y: 200
+            width: 200
+            height: 60
+            bodyType: Body.Kinematic
+            originPoint: Qt.point(100,30)
+            angularVelocity: 90
+            fixtures: Box {
+                anchors.fill: parent
+            }
+            Rectangle {
+                anchors.fill: parent
+                color: "yellow"
+            }
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    bodyBox.originPoint = Qt.point(mouse.x,mouse.y);
+                }
+            }
+        }
+
+        Body {
+            id: bodyCircle
+            x: 300
+            y: 200
+            width: 100
+            height: 100
+            bodyType: Body.Kinematic
+            originPoint: Qt.point(30,30)
+            angularVelocity: -90
+            fixtures: Circle {
+                anchors.fill: parent
+                radius: 50
+            }
+            Rectangle {
+                anchors.fill: parent
+                radius: 50
+                gradient: Gradient {
+                    GradientStop { position: 0.0; color: "blue" }
+                    GradientStop { position: 0.75; color: "magenta" }
+                }
+            }
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    bodyCircle.originPoint = Qt.point(mouse.x,mouse.y);
+                }
+            }
+        }
+
+        Body {
+            id: bodyPolygon
+            x: 450
+            y: 200
+            width: 100
+            height: 100
+            bodyType: Body.Kinematic
+            originPoint: Qt.point(50,20)
+            angularVelocity: 180
+            fixtures: Polygon {
+                anchors.fill: parent
+                vertices: [
+                    Qt.point(50,0),
+                    Qt.point(0,100),
+                    Qt.point(100,100)
+                ]
+            }
+            Canvas {
+                id: bodyPolygonCanvas;
+                anchors.fill: parent
+                onPaint: {
+                    var context = bodyPolygonCanvas.getContext("2d");
+                    context.beginPath();
+                    context.moveTo(50,0);
+                    context.lineTo(0,100);
+                    context.lineTo(100,100);
+                    context.lineTo(50,0);
+                    context.fillStyle = "green";
+                    context.fill();
+                }
+            }
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    bodyPolygon.originPoint = Qt.point(mouse.x,mouse.y);
+                }
+            }
+        }
+
+        Body {
+            id: bodyChain
+            x: 650
+            y: 200
+            width: 80
+            height: 200
+            bodyType: Body.Kinematic
+            originPoint: Qt.point(40,100)
+            angularVelocity: -45
+            fixtures: Chain {
+                anchors.fill: parent
+                vertices: [
+                    Qt.point(0,0),
+                    Qt.point(20,100),
+                    Qt.point(0,200),
+                    Qt.point(80,200),
+                    Qt.point(60,100),
+                    Qt.point(80,0)
+                ]
+                loop: true
+            }
+            Canvas {
+                id: bodyChainCanvas;
+                anchors.fill: parent
+                onPaint: {
+                    var context = bodyChainCanvas.getContext("2d");
+                    context.beginPath();
+                    context.moveTo(0,0);
+                    context.lineTo(20,100);
+                    context.lineTo(0,200);
+                    context.lineTo(80,200);
+                    context.lineTo(60,100);
+                    context.lineTo(80,0);
+                    context.lineTo(0,0);
+                    context.strokeStyle = "orange";
+                    context.stroke();
+                }
+            }
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    bodyChain.originPoint = Qt.point(mouse.x,mouse.y);
+                }
+            }
+        }
+
+        Body {
+            x: 690
+            y: 240
+            width: 20
+            height: 20
+            bodyType: Body.Dynamic
+            fixtures: Circle {
+                anchors.fill: parent
+                radius: 10
+                density: 0.5
+                restitution: 0.8
+            }
+            Rectangle {
+                anchors.fill: parent
+                radius: 10
+                color: "aqua"
+            }
+        }
+
+        Rectangle {
+            id: debugButton
+            x: 10
+            y: 10
+            width: 120
+            height: 30
+            Text {
+                id: debugButtonText
+                text: "Debug view: on"
+                anchors.centerIn: parent
+            }
+            color: "#DEDEDE"
+            border.color: "#999"
+            radius: 5
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    debugDraw.visible = !debugDraw.visible
+                    debugButtonText.text = debugDraw.visible ? "Debug view: on" : "Debug view: off"
+                }
+            }
+        }
+
+        Rectangle {
+            id: centerButton
+            x: 140
+            y: 10
+            width: 120
+            height: 30
+            Text {
+                text: "All to center"
+                anchors.centerIn: parent
+            }
+            color: "#DEDEDE"
+            border.color: "#999"
+            radius: 5
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    bodyBox.transformOrigin = Item.Center;
+                    bodyCircle.transformOrigin = Item.Center;
+                    bodyPolygon.transformOrigin = Item.Center;
+                    bodyChain.transformOrigin = Item.Center;
+                }
+            }
+        }
+
+        Rectangle {
+            id: randomButton
+            x: 270
+            y: 10
+            width: 120
+            height: 30
+            Text {
+                text: "All to random"
+                anchors.centerIn: parent
+            }
+            color: "#DEDEDE"
+            border.color: "#999"
+            radius: 5
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    bodyBox.originPoint = Qt.point(Math.random() * 100,Math.random() * 100);
+                    bodyCircle.originPoint = Qt.point(Math.random() * 100,Math.random() * 100);
+                    bodyPolygon.originPoint = Qt.point(Math.random() * 100,Math.random() * 100);
+                    bodyChain.originPoint = Qt.point(Math.random() * 100,Math.random() * 100);
+                }
+            }
+        }
+
+        DebugDraw {
+            id: debugDraw
+            world: world
+            anchors.fill: parent
+            opacity: 0.6
+            visible: true
+        }
+    }
+}


### PR DESCRIPTION
The patch adds ability to change origin point of rotation. Along with `angularVelocity` it should be very useful.
The point can be defined in two ways:
- using QML property `Item.transformOrigin`. Actually it's a little limited. You can define only 9 points (center, corners etc.)
- using new `originPoint` property. A point is defines in local coordinates of `Body`.

Conversion from `transformOrigin` to `originPoint` executed automatically (but not back)

Known issues:
- when you do the following:
  * transformOrigin = Item.Center
  * originPoint = Qt.point(1,1)
  * transformOrigin = Item.Center
  
the last action will be ignored just because transformOrigin was not changed from QML view

As usual, added a simple example to test the functionality.