### PR TITLE
Add new item to control contacts (ContactFilter)

### DIFF
--- a/box2d-static.pri
+++ b/box2d-static.pri
@@ -35,7 +35,8 @@ SOURCES += $$PWD/box2dplugin.cpp \
     $$PWD/box2dwheeljoint.cpp \
     $$PWD/box2dmousejoint.cpp \
     $$PWD/box2dgearjoint.cpp \
-    $$PWD/box2dropejoint.cpp
+    $$PWD/box2dropejoint.cpp \
+    $$PWD/box2dcontactfilter.cpp
 
 
 
@@ -57,5 +58,6 @@ HEADERS += \
     $$PWD/box2dwheeljoint.h \
     $$PWD/box2dmousejoint.h \
     $$PWD/box2dgearjoint.h \
-    $$PWD/box2dropejoint.h
+    $$PWD/box2dropejoint.h \
+    $$PWD/box2dcontactfilter.h
 

--- a/box2d.pro
+++ b/box2d.pro
@@ -38,7 +38,8 @@ SOURCES += box2dplugin.cpp \
     box2dwheeljoint.cpp \
     box2dmousejoint.cpp \
     box2dgearjoint.cpp \
-    box2dropejoint.cpp 
+    box2dropejoint.cpp \
+    box2dcontactfilter.cpp
 
 HEADERS += \
     box2dplugin.h \
@@ -58,4 +59,5 @@ HEADERS += \
     box2dwheeljoint.h \
     box2dmousejoint.h \
     box2dgearjoint.h \
-    box2dropejoint.h
+    box2dropejoint.h \
+    box2dcontactfilter.h

--- a/box2dcontactfilter.cpp
+++ b/box2dcontactfilter.cpp
@@ -1,0 +1,101 @@
+/*
+ * box2dcontactfilter.cpp
+ * Copyright (c) 2014 Ruslan Mouchlynin <ruslan@khvmntk.ru>
+ *
+ * This file is part of the Box2D QML plugin.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software in
+ *    a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#include "box2dcontactfilter.h"
+
+#include "box2dworld.h"
+#include "box2dfixture.h"
+
+Box2DContactFilter::Box2DContactFilter(QObject *parent) :
+    QObject(parent),
+    mEnabled(true),
+    mWorld(0)
+{
+}
+
+bool Box2DContactFilter::ShouldCollide(b2Fixture *fixtureA, b2Fixture *fixtureB)
+{
+    mResult = true;
+    emit contacted(toBox2DFixture(fixtureA),
+                   toBox2DFixture(fixtureB));
+
+    return mResult;
+}
+
+void Box2DContactFilter::classBegin()
+{
+}
+
+void Box2DContactFilter::componentComplete()
+{
+    installContactFilter(mEnabled);
+}
+
+bool Box2DContactFilter::isEnabled() const
+{
+    return mEnabled;
+}
+
+void Box2DContactFilter::setEnabled(bool enabled)
+{
+    if(mEnabled == enabled)
+        return;
+    mEnabled = enabled;
+    installContactFilter(mEnabled);
+    emit enabledChanged();
+}
+
+bool Box2DContactFilter::result() const
+{
+    return mResult;
+}
+
+void Box2DContactFilter::setResult(bool result)
+{
+    mResult = result;
+}
+
+Box2DWorld *Box2DContactFilter::world() const
+{
+    return mWorld;
+}
+
+void Box2DContactFilter::setWorld(Box2DWorld *world)
+{
+    if(mWorld == world)
+        return;
+    mWorld = world;
+    emit worldChanged();
+}
+
+void Box2DContactFilter::installContactFilter(bool install)
+{
+    if(mWorld) {
+        if(install)
+            mWorld->world().SetContactFilter(this);
+        else
+            mWorld->world().SetContactFilter(0);
+    }
+}

--- a/box2dcontactfilter.h
+++ b/box2dcontactfilter.h
@@ -1,0 +1,74 @@
+/*
+ * box2dcontactfilter.h
+ * Copyright (c) 2014 Ruslan Mouchlynin <ruslan@khvmntk.ru>
+ *
+ * This file is part of the Box2D QML plugin.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software in
+ *    a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#ifndef BOX2DCONTACTFILTER_H
+#define BOX2DCONTACTFILTER_H
+
+#include <QObject>
+#include <QQmlParserStatus>
+
+#include <Box2D.h>
+
+class Box2DWorld;
+class Box2DFixture;
+
+class Box2DContactFilter : public QObject, public b2ContactFilter, public QQmlParserStatus
+{
+    Q_OBJECT
+    Q_INTERFACES(QQmlParserStatus)
+    Q_PROPERTY(bool enabled READ isEnabled WRITE setEnabled NOTIFY enabledChanged)
+    Q_PROPERTY(bool result READ result WRITE setResult)
+    Q_PROPERTY(Box2DWorld *world READ world WRITE setWorld NOTIFY worldChanged)
+
+public:
+    Box2DContactFilter(QObject *parent = 0);
+    bool ShouldCollide(b2Fixture *fixtureA, b2Fixture *fixtureB);
+
+    void classBegin();
+    void componentComplete();
+
+protected:
+    bool mEnabled;
+    bool mResult;
+    Box2DWorld *mWorld;
+
+    bool isEnabled() const;
+    void setEnabled(bool enabled);
+
+    bool result() const;
+    void setResult(bool result);
+
+    Box2DWorld *world() const;
+    void setWorld(Box2DWorld *world);
+
+    void installContactFilter(bool install);
+
+signals:
+    void contacted(Box2DFixture *fixtureA,Box2DFixture *fixtureB);
+    void enabledChanged();
+    void worldChanged();
+};
+
+#endif // BOX2DCONTACTFILTER_H

--- a/box2dplugin.cpp
+++ b/box2dplugin.cpp
@@ -44,6 +44,7 @@
 #include "box2dgearjoint.h"
 #include "box2dropejoint.h"
 #include "box2dcontact.h"
+#include "box2dcontactfilter.h"
 
 Box2DPlugin::Box2DPlugin(QObject *parent) :
     QQmlExtensionPlugin(parent)
@@ -79,6 +80,7 @@ void Box2DPlugin::registerTypes(const char *uri)
     qmlRegisterType<Box2DMouseJoint>(uri, 1, 1, "MouseJoint");
     qmlRegisterType<Box2DGearJoint>(uri, 1, 1, "GearJoint");
     qmlRegisterType<Box2DRopeJoint>(uri, 1, 1, "RopeJoint");
+    qmlRegisterType<Box2DContactFilter>(uri, 1, 1, "ContactFilter");
 
     qmlRegisterUncreatableType<Box2DContact>(uri, 1,0, "Contact",QStringLiteral("Contact class"));
 }


### PR DESCRIPTION
One more item to control over contacts.
It's very simple one, like that:

``` javascript
ContactFilter {
     world: world
     onContacted: {
         if( (fixtureA.someflag == fixtureB.someflag)
             contactFilter.result = false;
        }
}
```

so id `contactFilter.result == false` all contacts with these two fixtures are ignored.

I will add test code to `contacts` example later if this path will be approved.
