### PR TITLE
Simplified raycast API

### DIFF
--- a/box2draycast.cpp
+++ b/box2draycast.cpp
@@ -25,19 +25,12 @@
 
 #include "box2draycast.h"
 
-#include "box2dworld.h"
 #include "box2dfixture.h"
 
 
 Box2DRayCast::Box2DRayCast(QObject *parent) :
     QObject(parent),
-    mComponentComplete(false),
-    mPoint1(0,0),
-    mPoint2(0,0),
-    mRepeat(false),
-    mResult(Continue),
-    mRunning(false),
-    mWorld(0)
+    mMaxFraction(-1.0f)
 {
 }
 
@@ -46,129 +39,12 @@ float32 Box2DRayCast::ReportFixture(b2Fixture *fixture,
                                     const b2Vec2 &normal,
                                     float32 fraction)
 {
-    emit casted(toBox2DFixture(fixture),
-                toPixels(point),
-                toPixels(normal),
-                fraction);
+    mMaxFraction = -1.0f;
 
-    return mResult == Clip ? fraction : static_cast<qreal>(mResult);
-}
+    emit fixtureReported(toBox2DFixture(fixture),
+                         toPixels(point),
+                         toPixels(normal),
+                         fraction);
 
-void Box2DRayCast::classBegin()
-{
-}
-
-void Box2DRayCast::componentComplete()
-{
-    mComponentComplete = true;
-    if(mRunning) {
-        if(mRepeat)
-            startLoop(true);
-        else
-            cast();
-    }
-}
-
-void Box2DRayCast::cast()
-{
-    if(mWorld && mRunning) {
-        mWorld->world().RayCast(this,mPoint1,mPoint2);
-        if(!mRepeat)
-            setRunning(false);
-    }
-}
-
-void Box2DRayCast::startLoop(bool start)
-{
-    if(start)
-        connect(mWorld,SIGNAL(stepped()),SLOT(cast()));
-    else
-    {
-        mWorld->disconnect(this);
-        setRunning(false);
-    }
-}
-
-bool Box2DRayCast::repeat() const
-{
-    return mRepeat;
-}
-
-void Box2DRayCast::setRepeat(bool repeat)
-{
-    if(mRepeat != repeat) {
-        mRepeat = repeat;
-        if(mComponentComplete) {
-            startLoop(mRepeat);
-            emit repeatChanged();
-        }
-    }
-}
-
-Box2DRayCast::CastResult Box2DRayCast::result() const
-{
-    return mResult;
-}
-
-QPointF Box2DRayCast::point1() const
-{
-    return toPixels(mPoint1);
-}
-
-void Box2DRayCast::setPoint1(const QPointF &point1)
-{
-    if(this->point1() == point1)
-        return;
-    mPoint1 = toMeters(point1);
-    emit point1Changed();
-}
-
-QPointF Box2DRayCast::point2() const
-{
-    return toPixels(mPoint2);
-}
-
-void Box2DRayCast::setPoint2(const QPointF &point2)
-{
-    if(this->point2() == point2)
-        return;
-    mPoint2 = toMeters(point2);
-    emit point2Changed();
-}
-
-void Box2DRayCast::setResult(Box2DRayCast::CastResult result)
-{
-    mResult = result;
-}
-
-bool Box2DRayCast::running() const
-{
-    return mRunning;
-}
-
-void Box2DRayCast::setRunning(bool running)
-{
-    if(mRunning == running)
-        return;
-    mRunning = running;
-    if(mComponentComplete) {
-        if(mRepeat)
-            startLoop(mRunning);
-        else
-            cast();
-        emit runningChanged();
-    }
-}
-
-Box2DWorld *Box2DRayCast::world() const
-{
-    return mWorld;
-}
-
-void Box2DRayCast::setWorld(Box2DWorld *world)
-{
-    if(mWorld != world) {
-        mWorld = world;
-        emit worldChanged();
-    }
+    return mMaxFraction;
 }

--- a/box2draycast.h
+++ b/box2draycast.h
@@ -27,82 +27,47 @@
 #define BOX2DRAYCAST_H
 
 #include <QObject>
-#include <QQmlParserStatus>
 #include <QPointF>
-#include <QVariant>
 
 #include <Box2D.h>
 
 class Box2DFixture;
-class Box2DWorld;
 
-class Box2DRayCast : public QObject, public QQmlParserStatus, public b2RayCastCallback
+class Box2DRayCast : public QObject, public b2RayCastCallback
 {
     Q_OBJECT
-    Q_INTERFACES(QQmlParserStatus)
-    Q_ENUMS(CastResult Loops)
 
-    Q_PROPERTY(QPointF point1 READ point1 WRITE setPoint1 NOTIFY point1Changed)
-    Q_PROPERTY(QPointF point2 READ point2 WRITE setPoint2 NOTIFY point2Changed)
-    Q_PROPERTY(bool repeat READ repeat WRITE setRepeat NOTIFY repeatChanged)
-    Q_PROPERTY(CastResult result READ result WRITE setResult)
-    Q_PROPERTY(bool running READ running WRITE setRunning NOTIFY runningChanged)
-    Q_PROPERTY(Box2DWorld *world READ world WRITE setWorld NOTIFY worldChanged)
+    Q_PROPERTY(float maxFraction READ maxFraction WRITE setMaxFraction)
 
 public:
-    enum CastResult {
-        Ignore = -1,
-        Terminate = 0,
-        Continue = 1,
-        Clip = 2
-    };
-
     Box2DRayCast(QObject *parent = 0);
-    float32 ReportFixture (b2Fixture *fixture, const b2Vec2 &point, const b2Vec2 &normal, float32 fraction);
 
-    void classBegin();
-    void componentComplete();
+    float32 ReportFixture(b2Fixture *fixture,
+                          const b2Vec2 &point,
+                          const b2Vec2 &normal,
+                          float32 fraction);
 
-protected:
-    QPointF point1() const;
-    void setPoint1(const QPointF &point1);
-
-    QPointF point2() const;
-    void setPoint2(const QPointF &point2);
-
-    bool repeat() const;
-    void setRepeat(bool repeat);
-
-    CastResult result() const;
-    void setResult(CastResult result);
-
-    bool running() const;
-    void setRunning(bool running);
-
-    Box2DWorld * world() const;
-    void setWorld(Box2DWorld *world);
-
-    void startLoop(bool start);
-
-private:
-    bool mComponentComplete;
-    b2Vec2 mPoint1;
-    b2Vec2 mPoint2;
-    bool mRepeat;
-    CastResult mResult;
-    bool mRunning;
-    Box2DWorld *mWorld;
-
-private slots:
-    void cast();
+    float maxFraction() const;
+    void setMaxFraction(float maxFraction);
 
 signals:
-    void casted(Box2DFixture *fixture, const QPointF &point, const QPointF &normal, qreal fraction);
-    void point1Changed();
-    void point2Changed();
-    void repeatChanged();
-    void runningChanged();
-    void worldChanged();
+    void fixtureReported(Box2DFixture *fixture,
+                         const QPointF &point,
+                         const QPointF &normal,
+                         qreal fraction);
+
+private:
+    float mMaxFraction;
 };
+
+inline float Box2DRayCast::maxFraction() const
+{
+    return mMaxFraction;
+}
+
+inline void Box2DRayCast::setMaxFraction(float maxFraction)
+{
+    mMaxFraction = maxFraction;
+}
 
 #endif // BOX2DRAYCAST_H

--- a/box2dworld.cpp
+++ b/box2dworld.cpp
@@ -31,6 +31,7 @@
 #include "box2dcontact.h"
 #include "box2dfixture.h"
 #include "box2djoint.h"
+#include "box2draycast.h"
 
 StepDriver::StepDriver(Box2DWorld *world)
     : QAbstractAnimation(world)
@@ -291,6 +292,13 @@ void Box2DWorld::step()
     }
 
     emit stepped();
+}
+
+void Box2DWorld::rayCast(Box2DRayCast *rayCast,
+                         const QPointF &point1,
+                         const QPointF &point2)
+{
+    mWorld.RayCast(rayCast, toMeters(point1), toMeters(point2));
 }
 
 void Box2DWorld::itemChange(ItemChange change, const ItemChangeData &value)

--- a/box2dworld.h
+++ b/box2dworld.h
@@ -37,6 +37,7 @@ class Box2DContact;
 class Box2DFixture;
 class Box2DJoint;
 class Box2DWorld;
+class Box2DRayCast;
 class ContactListener;
 class StepDriver;
 
@@ -159,6 +160,9 @@ public:
 
     Q_INVOKABLE void step();
     Q_INVOKABLE void clearForces();
+    Q_INVOKABLE void rayCast(Box2DRayCast *rayCast,
+                             const QPointF &point1,
+                             const QPointF &point2);
 
 signals:
     void initialized();

--- a/examples/raycast/main.qml
+++ b/examples/raycast/main.qml
@@ -125,14 +125,11 @@ Rectangle {
         }
 
         RayCast {
-            id: rayCastPermanent
-            world: world
-            repeat: true
-            point1: Qt.point(40,200)
-            point2: Qt.point(fractionSlider.value * 10,200)
-            running: true
-            onCasted: {
-                if(fixture.isBall === true) {
+            id: sensorRay
+            property point point1: Qt.point(40, 200)
+            property point point2: Qt.point(fractionSlider.value * 10, 200)
+            onFixtureReported: {
+                if (fixture.isBall) {
                     intersectionPoint.x = point.x - 5;
                     intersectionPoint.y = point.y - 5;
                     intersectionPoint.opacity = 1;
@@ -142,9 +139,14 @@ Rectangle {
                 }
             }
         }
+        Connections {
+            target: world
+            onStepped: world.rayCast(sensorRay,
+                                     sensorRay.point1,
+                                     sensorRay.point2)
+        }
 
         Rectangle {
-            id: rayPermanent
             x: 40
             y: 200
             width: 10 * fractionSlider.value
@@ -154,19 +156,15 @@ Rectangle {
         }
 
         RayCast {
-            id: rayCastImpulse
-            world: world
-            repeat: false
-            running: false
-            point1: Qt.point(40,300);
-            point2: Qt.point(700,300);
-            onCasted: {
-                fixture.parent.burn = true;
+            id: laserRay
+            onFixtureReported: fixture.parent.burn = true
+            function cast() {
+                world.rayCast(this, Qt.point(40, 300), Qt.point(700, 300))
             }
         }
 
         Rectangle {
-            id: rayImpulse
+            id: laser
             x: 40
             y: 300
             width: 700
@@ -175,7 +173,7 @@ Rectangle {
             opacity: 0
             PropertyAnimation {
                 id: rayImpulseFadeoutAnimation
-                target: rayImpulse
+                target: laser
                 property: "opacity"
                 to: 0
                 duration: 100
@@ -313,8 +311,8 @@ Rectangle {
         running: true
         repeat: true
         onTriggered: {
-            rayCastImpulse.running = true;
-            rayImpulse.opacity = 1;
+            laserRay.cast();
+            laser.opacity = 1;
             rayImpulseFadeoutAnimation.running = true;
         }
     }


### PR DESCRIPTION
- Added `World.rayCast` function, taking a `RayCast` object and the start and end points for the ray.
- Removed `RayCast.point1`, `RayCast.point2`, `RayCast.world`, `RayCast.repeat` and `RayCast.running`. All these properties can be trivially implemented on the QML side.
- Renamed `RayCast.result` to `RayCast.maxFraction`
- Renamed `RayCast.onCast` to `RayCast.onFixtureReported`
- Adjusted raycast example accordingly
