### PR TITLE
Added some missing mapping functions to Body

### DIFF
--- a/box2dbody.cpp
+++ b/box2dbody.cpp
@@ -338,6 +338,13 @@ QPointF Box2DBody::getWorldCenter() const
     return QPointF();
 }
 
+QPointF Box2DBody::getLocalCenter() const
+{
+    if (mBody)
+        return mWorld->toPixels(mBody->GetLocalCenter());
+    return QPointF();
+}
+
 void Box2DBody::applyForce(const QPointF &force, const QPointF &point)
 {
     if (mBody)
@@ -364,6 +371,34 @@ void Box2DBody::resetMassData()
 float Box2DBody::getInertia() const
 {
     return mBody ? mBody->GetInertia() : 0.0;
+}
+
+QPointF Box2DBody::toWorldPoint(const QPointF &localPoint) const
+{
+    if (mBody)
+        return mWorld->toPixels(mBody->GetWorldPoint(mWorld->toMeters(localPoint)));
+    return QPointF();
+}
+
+QPointF Box2DBody::toWorldVector(const QPointF &localVector) const
+{
+    if (mBody)
+        return mWorld->toPixels(mBody->GetWorldVector(mWorld->toMeters(localVector)));
+    return QPointF();
+}
+
+QPointF Box2DBody::toLocalPoint(const QPointF &worldPoint) const
+{
+    if (mBody)
+        return mWorld->toPixels(mBody->GetLocalPoint(mWorld->toMeters(worldPoint)));
+    return QPointF();
+}
+
+QPointF Box2DBody::toLocalVector(const QPointF &worldVector) const
+{
+    if (mBody)
+        return mWorld->toPixels(mBody->GetLocalVector(mWorld->toMeters(worldVector)));
+    return QPointF();
 }
 
 QPointF Box2DBody::getLinearVelocityFromWorldPoint(const QPointF &point) const

--- a/box2dbody.h
+++ b/box2dbody.h
@@ -113,9 +113,14 @@ public:
     Q_INVOKABLE void applyLinearImpulse(const QPointF &impulse, const QPointF &point);
     Q_INVOKABLE void applyAngularImpulse(qreal impulse);
     Q_INVOKABLE QPointF getWorldCenter() const;
+    Q_INVOKABLE QPointF getLocalCenter() const;
     Q_INVOKABLE float getMass() const;
     Q_INVOKABLE void resetMassData();
     Q_INVOKABLE float getInertia() const;
+    Q_INVOKABLE QPointF toWorldPoint(const QPointF &localPoint) const;
+    Q_INVOKABLE QPointF toWorldVector(const QPointF &localVector) const;
+    Q_INVOKABLE QPointF toLocalPoint(const QPointF &worldPoint) const;
+    Q_INVOKABLE QPointF toLocalVector(const QPointF &worldVector) const;
     Q_INVOKABLE QPointF getLinearVelocityFromWorldPoint(const QPointF &point) const;
     Q_INVOKABLE QPointF getLinearVelocityFromLocalPoint(const QPointF &point) const;
     Q_INVOKABLE void addFixture(Box2DFixture *fixture);


### PR DESCRIPTION
- Body.getLocalCenter()
- Body.toWorldPoint(localPoint)
- Body.toWorldVector(localVector)
- Body.toLocalPoint(worldPoint)
- Body.toLocalVector(worldVector)

For some of these of course also `Item.mapToItem` and `Item.mapFromItem` could be used, but I don't think it hurts to have them anyway.
