### PR TITLE
Change render system for the DebugDraw item to scene graph

### DIFF
--- a/box2ddebugdraw.h
+++ b/box2ddebugdraw.h
@@ -1,6 +1,7 @@
 /*
  * box2ddebugdraw.h
  * Copyright (c) 2010 Thorbjørn Lindeijer <thorbjorn@lindeijer.nl>
+ * Copyright (c) 2014 Moukhlynin Ruslan <ruslan@khvmntk.ru>
  *
  * This file is part of the Box2D QML plugin.
  *
@@ -26,12 +27,11 @@
 #ifndef BOX2DDEBUGDRAW_H
 #define BOX2DDEBUGDRAW_H
 
-#include <QQuickPaintedItem>
 #include <QQuickItem>
 
 class Box2DWorld;
 
-class Box2DDebugDraw : public QQuickPaintedItem
+class Box2DDebugDraw : public QQuickItem
 {
     Q_ENUMS(DebugFlag)
     Q_OBJECT
@@ -60,7 +60,8 @@ public:
     Box2DWorld *world() const;
     void setWorld(Box2DWorld *world);
 
-    void paint(QPainter *);
+protected:
+    QSGNode *updatePaintNode(QSGNode * oldNode, UpdatePaintNodeData *);
 
 signals:
     void axisScaleChanged();


### PR DESCRIPTION
I've tried to turn the `DebugDraw` render system to use Scene graph.
Since I am newbie in GL painting all advices are appreciated!
As for me, I'm worried about recreating `oldNode` in `Box2DDebugDraw::updatePaintNode` instead of updating its geometry. But I have no idea at all how to link geometry data passed by Box2D to GL node. So I delete the node tree and recreate it each time step.
