### PR TITLE
Introduced Body.target

### DIFF
--- a/box2dworld.cpp
+++ b/box2dworld.cpp
@@ -259,10 +259,21 @@ void Box2DWorld::SayGoodbye(b2Fixture *fixture)
 
 void Box2DWorld::step()
 {
+    // Update Box2D state before stepping
+    for (b2Body *body = mWorld.GetBodyList(); body; body = body->GetNext()) {
+        Box2DBody *b = toBox2DBody(body);
+        if (b->transformDirty() && b->isActive())
+            b->updateTransform();
+    }
+
     mWorld.Step(mTimeStep, mVelocityIterations, mPositionIterations);
 
-    for (b2Body *body = mWorld.GetBodyList(); body; body = body->GetNext())
-        toBox2DBody(body)->synchronize();
+    // Update QML state after stepping
+    for (b2Body *body = mWorld.GetBodyList(); body; body = body->GetNext()) {
+        Box2DBody *b = toBox2DBody(body);
+        if (b->isActive() && b->bodyType() != Box2DBody::Static)
+            b->synchronize();
+    }
 
     // Emit contact signals
     foreach (const ContactEvent &event, mContactListener->events()) {
@@ -305,9 +316,12 @@ void Box2DWorld::itemChange(ItemChange change, const ItemChangeData &value)
 {
     if (isComponentComplete()) {
         if (change == ItemChildAddedChange) {
-            QObject *child = value.item;
-            if (Box2DBody *body = dynamic_cast<Box2DBody*>(child))
-                body->initialize(this);
+            /*
+             * Here it is necessary to initialize any child bodies of the added
+             * child, because they have no other way to get notified about
+             * being added to this world.
+             */
+            initializeBodies(value.item);
         }
     }
 
@@ -317,8 +331,8 @@ void Box2DWorld::itemChange(ItemChange change, const ItemChangeData &value)
 void Box2DWorld::initializeBodies(QQuickItem *parent)
 {
     foreach (QQuickItem *item, parent->childItems()) {
-        if (Box2DBody *body = dynamic_cast<Box2DBody *>(item))
-            body->initialize(this);
+        if (Box2DBody *body = item->property("_Box2DBody").value<Box2DBody *>())
+            body->setWorld(this);
 
         initializeBodies(item);
     }

--- a/examples/demolition/demolition.qml
+++ b/examples/demolition/demolition.qml
@@ -19,50 +19,52 @@ Image {
     // A wheel that will be created dynamically
     Component {
         id: wheelComponent
-        Body {
-            id: wheelBody
-            sleepingAllowed: true
-			bodyType: Body.Dynamic
-			width:80
-			height:80
-            fixtures: Circle {
-                id: circle
-                radius: 40
-                density: 6
-                friction: 1.0
-                restitution: 0.6
-            }
-            Image {
-                id: circleRect
-                anchors.centerIn: parent
-                smooth: true
-                source: "images/wheel.png"
-                MouseArea {
-                    anchors.fill: parent
-                    onReleased: timer.running = false
-                    onPressed: {
-                        if(wheelBody.x < (world.width / 2)) {
-                            timer.clockwise = true
-                        }
-                        else {
-                            timer.clockwise = false
-                        }
+        Image {
+            id: wheel
+            transformOrigin: Item.TopLeft
 
-                        timer.running = true
+            smooth: true
+            source: "images/wheel.png"
+
+            Body {
+                id: wheelBody
+                sleepingAllowed: true
+                bodyType: Body.Dynamic
+                target: wheel
+                fixtures: Circle {
+                    id: circle
+                    radius: wheel.width / 2
+                    density: 6
+                    friction: 1.0
+                    restitution: 0.6
+                }
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                onReleased: timer.running = false
+                onPressed: {
+                    if(wheel.x < (world.width / 2)) {
+                        timer.clockwise = true
+                    }
+                    else {
+                        timer.clockwise = false
                     }
 
-                    Timer {
-                        id: timer
-                        property bool clockwise
-                        interval: 100
-                        repeat: true
-                        onTriggered: {
-                            if(clockwise) {
-                                wheelBody.applyTorque(-3000)
-                            }
-                            else {
-                                wheelBody.applyTorque(3000)
-                            }
+                    timer.running = true
+                }
+
+                Timer {
+                    id: timer
+                    property bool clockwise
+                    interval: 100
+                    repeat: true
+                    onTriggered: {
+                        if(clockwise) {
+                            wheelBody.applyTorque(-3000)
+                        }
+                        else {
+                            wheelBody.applyTorque(3000)
                         }
                     }
                 }
@@ -98,8 +100,8 @@ Image {
                 anchors.fill: parent
                 onPressAndHold: {
                     var wheel = wheelComponent.createObject(world)
-                    wheel.x = mouse.x
-                    wheel.y = mouse.y
+                    wheel.x = mouse.x - wheel.width / 2
+                    wheel.y = mouse.y - wheel.height / 2
                 }
             }
 
@@ -196,10 +198,10 @@ Image {
         }
     }
 	DebugDraw {
-            id: debugDraw
-            anchors.fill: parent
-            world: world
-            opacity: 0.75
-            visible: false
-        }
+        id: debugDraw
+        anchors.fill: parent
+        world: world
+        opacity: 0.75
+        visible: false
+    }
 }


### PR DESCRIPTION
This allows using any existing item as the target for physics emulation, rather than requiring such items to be wrapped by a Body item. I've adjust the "demolition" example to show how physics properties can be applied to an existing QML `Image` item.

There's one `TODO` left in the change that I intend to fix before this gets merged, but since fixing that won't change anything fundamental I've decided to open this pull request already so that it can get an initial review.

This property is being introduced to allow for a cleaner integration with other libraries like V-Play and Bacon2D. (see Bacon2D/Bacon2D#67)

Since it required me to put an explicit `transformOrigin: Item.TopLeft` in `demolition.qml`, I'm now also convinced that #52 is a necessary feature and will try to find some time for reviewing that patch later (though unfortunately I'll be rather busy with family visiting over the next few days).
