### PR TITLE
Fixed assertion when Box fixtures have very small size

### DIFF
--- a/box2dfixture.cpp
+++ b/box2dfixture.cpp
@@ -200,8 +200,8 @@ b2Shape *Box2DBox::createShape()
                          y() + halfHeight);
 
     b2PolygonShape *shape = new b2PolygonShape;
-    shape->SetAsBox(mBody->world()->toMeters(halfWidth),
-                    mBody->world()->toMeters(halfHeight),
+    shape->SetAsBox(b2Max(mBody->world()->toMeters(halfWidth), b2_linearSlop),
+                    b2Max(mBody->world()->toMeters(halfHeight), b2_linearSlop),
                     mBody->world()->toMeters(center),
                     toRadians(rotation()));
 


### PR DESCRIPTION
This is the fix I would propose for issue #74.

Rather than creating no box at all, it makes sure that a Box fixture dimensions are always at least as big as the `b2_linearSlop`. My reasoning is that if somebody would want no box at all, it would not be there in the first place.
