### PR TITLE
Removed Fixture.beginContact and Fixture.endContact signals

### DIFF
--- a/box2d-static.pri
+++ b/box2d-static.pri
@@ -21,6 +21,7 @@ include(Box2D/box2d.pri)
 SOURCES += $$PWD/box2dplugin.cpp \
     $$PWD/box2dworld.cpp \
     $$PWD/box2dcontact.cpp \
+    $$PWD/box2dcontactlistener.cpp \
     $$PWD/box2dbody.cpp \
     $$PWD/box2dfixture.cpp \
     $$PWD/box2ddebugdraw.cpp \
@@ -44,6 +45,7 @@ HEADERS += \
     $$PWD/box2dplugin.h \
     $$PWD/box2dworld.h \
     $$PWD/box2dcontact.h \
+    $$PWD/box2dcontactlistener.h \
     $$PWD/box2dbody.h \
     $$PWD/box2dfixture.h \
     $$PWD/box2ddebugdraw.h \

--- a/box2d.pro
+++ b/box2d.pro
@@ -24,6 +24,7 @@ INSTALLS += target qmldir
 SOURCES += box2dplugin.cpp \
     box2dworld.cpp \
     box2dcontact.cpp \
+    box2dcontactlistener.cpp \
     box2dbody.cpp \
     box2dfixture.cpp \
     box2ddebugdraw.cpp \
@@ -45,6 +46,7 @@ HEADERS += \
     box2dplugin.h \
     box2dworld.h \
     box2dcontact.h \
+    box2dcontactlistener.h \
     box2dbody.h \
     box2dfixture.h \
     box2ddebugdraw.h \

--- a/box2dcontact.cpp
+++ b/box2dcontact.cpp
@@ -34,12 +34,7 @@ Box2DContact::Box2DContact(b2Contact *contact) :
 {
 }
 
-void Box2DContact::setContact(b2Contact *contact)
-{
-    mContact = contact;
-}
-
-bool Box2DContact::isTouching()
+bool Box2DContact::isTouching() const
 {
     return mContact->IsTouching();
 }
@@ -56,18 +51,16 @@ void Box2DContact::setEnabled(bool enabled)
 
 Box2DFixture *Box2DContact::fixtureA() const
 {
-    b2Fixture *fixture = mContact->GetFixtureA();
-    if(fixture)
+    if (b2Fixture *fixture = mContact->GetFixtureA())
         return toBox2DFixture(fixture);
-    return NULL;
+    return 0;
 }
 
 Box2DFixture *Box2DContact::fixtureB() const
 {
-    b2Fixture *fixture = mContact->GetFixtureB();
-    if(fixture)
+    if (b2Fixture *fixture = mContact->GetFixtureB())
         return toBox2DFixture(fixture);
-    return NULL;
+    return 0;
 }
 
 int Box2DContact::childIndexA() const
@@ -80,7 +73,7 @@ int Box2DContact::childIndexB() const
     return mContact->GetChildIndexB();
 }
 
-qreal Box2DContact::getFriction() const
+qreal Box2DContact::friction() const
 {
     return mContact->GetFriction();
 }
@@ -95,7 +88,7 @@ void Box2DContact::resetFriction()
     mContact->ResetFriction();
 }
 
-qreal Box2DContact::getRestitution() const
+qreal Box2DContact::restitution() const
 {
     return mContact->GetRestitution();
 }
@@ -110,7 +103,7 @@ void Box2DContact::resetRestitution()
     mContact->ResetRestitution();
 }
 
-qreal Box2DContact::getTangentSpeed() const
+qreal Box2DContact::tangentSpeed() const
 {
     return mContact->GetTangentSpeed();
 }

--- a/box2dcontact.h
+++ b/box2dcontact.h
@@ -34,20 +34,21 @@ class Box2DFixture;
 class Box2DContact : public QObject
 {
     Q_OBJECT
+
     Q_PROPERTY(bool enabled READ isEnabled WRITE setEnabled)
     Q_PROPERTY(Box2DFixture *fixtureA READ fixtureA)
     Q_PROPERTY(Box2DFixture *fixtureB READ fixtureB)
     Q_PROPERTY(int childIndexA READ childIndexA)
     Q_PROPERTY(int childIndexB READ childIndexB)
-    Q_PROPERTY(qreal friction READ getFriction WRITE setFriction)
-    Q_PROPERTY(qreal restitution READ getRestitution WRITE setRestitution)
-    Q_PROPERTY(qreal tangentSpeed READ getTangentSpeed WRITE setTangentSpeed)
+    Q_PROPERTY(qreal friction READ friction WRITE setFriction)
+    Q_PROPERTY(qreal restitution READ restitution WRITE setRestitution)
+    Q_PROPERTY(qreal tangentSpeed READ tangentSpeed WRITE setTangentSpeed)
 
 public:
     Box2DContact(b2Contact *contact = 0);
     void setContact(b2Contact *contact);
 
-    Q_INVOKABLE bool isTouching();
+    Q_INVOKABLE bool isTouching() const;
     Q_INVOKABLE void resetFriction();
     Q_INVOKABLE void resetRestitution();
 
@@ -63,14 +64,20 @@ protected:
     int childIndexA() const;
     int childIndexB() const;
 
-    qreal getFriction() const;
+    qreal friction() const;
     void setFriction(qreal friction);
 
-    qreal getRestitution() const;
+    qreal restitution() const;
     void setRestitution(qreal restitution);
 
-    qreal getTangentSpeed() const;
+    qreal tangentSpeed() const;
     void setTangentSpeed(qreal speed);
 };
+
+
+inline void Box2DContact::setContact(b2Contact *contact)
+{
+    mContact = contact;
+}
 
 #endif // BOX2DCONTACT_H

--- a/box2dcontactlistener.cpp
+++ b/box2dcontactlistener.cpp
@@ -1,0 +1,57 @@
+/*
+ * box2dcontactlistener.cpp
+ * Copyright (c) 2014 Thorbjørn Lindeijer <thorbjorn@lindeijer.nl>
+ *
+ * This file is part of the Box2D QML plugin.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software in
+ *    a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#include "box2dcontactlistener.h"
+
+Box2DContactListener::Box2DContactListener(QObject *parent) :
+    QObject(parent)
+{
+}
+
+void Box2DContactListener::BeginContact(b2Contact *contact)
+{
+    mContact.setContact(contact);
+    emit beginContact(&mContact);
+}
+
+void Box2DContactListener::EndContact(b2Contact *contact)
+{
+    mContact.setContact(contact);
+    emit endContact(&mContact);
+}
+
+void Box2DContactListener::PreSolve(b2Contact *contact, const b2Manifold *oldManifold)
+{
+    Q_UNUSED(oldManifold)
+    mContact.setContact(contact);
+    emit preSolve(&mContact);
+}
+
+void Box2DContactListener::PostSolve(b2Contact *contact, const b2ContactImpulse *impulse)
+{
+    Q_UNUSED(impulse)
+    mContact.setContact(contact);
+    emit postSolve(&mContact);
+}

--- a/box2dcontactlistener.h
+++ b/box2dcontactlistener.h
@@ -1,0 +1,55 @@
+/*
+ * box2dcontactlistener.h
+ * Copyright (c) 2014 Thorbjørn Lindeijer <thorbjorn@lindeijer.nl>
+ *
+ * This file is part of the Box2D QML plugin.
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from
+ * the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software in
+ *    a product, an acknowledgment in the product documentation would be
+ *    appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#ifndef BOX2DCONTACTLISTENER_H
+#define BOX2DCONTACTLISTENER_H
+
+#include <QObject>
+
+#include "box2dcontact.h"
+
+class Box2DContactListener : public QObject, public b2ContactListener
+{
+    Q_OBJECT
+
+public:
+    explicit Box2DContactListener(QObject *parent = 0);
+
+    void BeginContact(b2Contact *contact);
+    void EndContact(b2Contact *contact);
+    void PreSolve(b2Contact *contact, const b2Manifold *oldManifold);
+    void PostSolve(b2Contact *contact, const b2ContactImpulse *impulse);
+
+signals:
+    void beginContact(Box2DContact *contact);
+    void endContact(Box2DContact *contact);
+    void preSolve(Box2DContact *contact);
+    void postSolve(Box2DContact *contact);
+
+private:
+    Box2DContact mContact;
+};
+
+#endif // BOX2DCONTACTLISTENER_H

--- a/box2dfixture.h
+++ b/box2dfixture.h
@@ -95,9 +95,6 @@ signals:
     void collidesWithChanged();
     void groupIndexChanged();
 
-    void beginContact(Box2DFixture *other);
-    void endContact(Box2DFixture *other);
-
 protected:
     virtual b2Shape *createShape() = 0;
     void recreateFixture();

--- a/box2dplugin.cpp
+++ b/box2dplugin.cpp
@@ -44,6 +44,7 @@
 #include "box2dgearjoint.h"
 #include "box2dropejoint.h"
 #include "box2dcontact.h"
+#include "box2dcontactlistener.h"
 #include "box2draycast.h"
 
 const int versionMajor = 2;
@@ -85,5 +86,6 @@ void Box2DPlugin::registerTypes(const char *uri)
     qmlRegisterType<Box2DRopeJoint>(uri, versionMajor, versionMinor, "RopeJoint");
     qmlRegisterType<Box2DRayCast>(uri, versionMajor, versionMinor, "RayCast");
 
+    qmlRegisterType<Box2DContactListener>(uri, versionMajor, versionMinor, "ContactListener");
     qmlRegisterUncreatableType<Box2DContact>(uri, versionMajor, versionMinor, "Contact", QStringLiteral("Contact class"));
 }

--- a/box2dworld.cpp
+++ b/box2dworld.cpp
@@ -29,6 +29,7 @@
 
 #include "box2dbody.h"
 #include "box2dcontact.h"
+#include "box2dcontactlistener.h"
 #include "box2dfixture.h"
 #include "box2djoint.h"
 #include "box2draycast.h"
@@ -51,75 +52,6 @@ void StepDriver::updateCurrentTime(int)
 }
 
 
-class ContactEvent
-{
-public:
-    enum Type {
-        BeginContact,
-        EndContact
-    };
-
-    Type type;
-    Box2DFixture *fixtureA;
-    Box2DFixture *fixtureB;
-};
-
-class ContactListener : public b2ContactListener
-{
-public:
-    explicit ContactListener(Box2DWorld *world);
-    void BeginContact(b2Contact *contact);
-    void EndContact(b2Contact *contact);
-    void PreSolve(b2Contact *contact, const b2Manifold *oldManifold);
-    void PostSolve(b2Contact *contact, const b2ContactImpulse *impulse);
-
-    void removeEvent(int index) { mEvents.removeAt(index); }
-    void clearEvents() { mEvents.clear(); }
-    const QList<ContactEvent> &events() { return mEvents; }
-
-private:
-    QList<ContactEvent> mEvents;
-    Box2DWorld *mWorld;
-    Box2DContact mContact;
-};
-
-ContactListener::ContactListener(Box2DWorld *world) :
-    mWorld(world)
-{
-}
-
-void ContactListener::BeginContact(b2Contact *contact)
-{
-    ContactEvent event;
-    event.type = ContactEvent::BeginContact;
-    event.fixtureA = toBox2DFixture(contact->GetFixtureA());
-    event.fixtureB = toBox2DFixture(contact->GetFixtureB());
-    mEvents.append(event);
-}
-
-void ContactListener::EndContact(b2Contact *contact)
-{
-    ContactEvent event;
-    event.type = ContactEvent::EndContact;
-    event.fixtureA = toBox2DFixture(contact->GetFixtureA());
-    event.fixtureB = toBox2DFixture(contact->GetFixtureB());
-    mEvents.append(event);
-}
-
-void ContactListener::PreSolve(b2Contact *contact, const b2Manifold *oldManifold)
-{
-    Q_UNUSED(oldManifold)
-    mContact.setContact(contact);
-    emit mWorld->preSolve(&mContact);
-}
-
-void ContactListener::PostSolve(b2Contact *contact, const b2ContactImpulse *impulse)
-{
-    Q_UNUSED(impulse)
-    mContact.setContact(contact);
-    emit mWorld->postSolve(&mContact);
-}
-
 Box2DWorld::Box2DWorld(QObject *parent) :
     QObject(parent),
     mWorld(b2Vec2(0.0f, -10.0f)),
@@ -132,7 +64,6 @@ Box2DWorld::Box2DWorld(QObject *parent) :
     mSynchronizing(false),
     mStepDriver(new StepDriver(this)),
     mProfile(new Box2DProfile(&mWorld, this)),
-    mEnableContactEvents(true),
     mPixelsPerMeter(32.0f)
 
 {
@@ -214,25 +145,15 @@ void Box2DWorld::setAutoClearForces(bool autoClearForces)
     emit autoClearForcesChanged();
 }
 
-void Box2DWorld::setEnableContactEvents(bool enableContactEvents)
+void Box2DWorld::setContactListener(Box2DContactListener *contactListener)
 {
-    if(enableContactEvents == mEnableContactEvents)
+    if (mContactListener == contactListener)
         return;
-    mEnableContactEvents = enableContactEvents;
-    enableContactListener(mEnableContactEvents);
 
-    emit enableContactEventsChanged();
-}
+    mContactListener = contactListener;
+    mWorld.SetContactListener(contactListener);
 
-void Box2DWorld::enableContactListener(bool enable)
-{
-    if (enable) {
-        mContactListener = new ContactListener(this);
-        mWorld.SetContactListener(mContactListener);
-    } else {
-        mWorld.SetContactListener(0);
-        delete mContactListener;
-    }
+    emit contactListenerChanged();
 }
 
 void Box2DWorld::setPixelsPerMeter(float pixelsPerMeter)
@@ -256,8 +177,6 @@ void Box2DWorld::componentComplete()
 {
     mComponentComplete = true;
 
-    enableContactListener(mEnableContactEvents);
-
     if (mIsRunning)
         mStepDriver->start();
 }
@@ -272,15 +191,7 @@ void Box2DWorld::SayGoodbye(b2Joint *joint)
 
 void Box2DWorld::SayGoodbye(b2Fixture *fixture)
 {
-    if (mEnableContactEvents) {
-        Box2DFixture *f = toBox2DFixture(fixture);
-
-        QList<ContactEvent> events = mContactListener->events();
-        for (int i = events.count() - 1; i >= 0; i--) {
-            if(events.at(i).fixtureA == f || events.at(i).fixtureB == f)
-                mContactListener->removeEvent(i);
-        }
-    }
+    Q_UNUSED(fixture)
 }
 
 void Box2DWorld::step()
@@ -306,26 +217,6 @@ void Box2DWorld::step()
     mSynchronizing = false;
 
     mProfile->mSynchronize = timer.GetMilliseconds();
-    timer.Reset();
-
-    if (mEnableContactEvents) {
-        // Emit contact signals
-        foreach (const ContactEvent &event, mContactListener->events()) {
-            switch (event.type) {
-            case ContactEvent::BeginContact:
-                emit event.fixtureA->beginContact(event.fixtureB);
-                emit event.fixtureB->beginContact(event.fixtureA);
-                break;
-            case ContactEvent::EndContact:
-                emit event.fixtureA->endContact(event.fixtureB);
-                emit event.fixtureB->endContact(event.fixtureA);
-                break;
-            }
-        }
-    }
-    mContactListener->clearEvents();
-
-    mProfile->mEmitSignals = timer.GetMilliseconds();
 
     emit stepped();
 }

--- a/box2dworld.h
+++ b/box2dworld.h
@@ -33,12 +33,11 @@
 
 #include <Box2D.h>
 
-class Box2DContact;
+class Box2DContactListener;
 class Box2DFixture;
 class Box2DJoint;
 class Box2DWorld;
 class Box2DRayCast;
-class ContactListener;
 class StepDriver;
 
 /**
@@ -77,7 +76,6 @@ class Box2DProfile : public QObject
     Q_PROPERTY(float broadphase READ broadphase CONSTANT)
     Q_PROPERTY(float solveTOI READ solveTOI CONSTANT)
     Q_PROPERTY(float synchronize READ synchronize CONSTANT)
-    Q_PROPERTY(float emitSignals READ emitSignals CONSTANT)
 
 public:
     explicit Box2DProfile(b2World *world, QObject *parent = 0)
@@ -94,14 +92,12 @@ public:
     float broadphase() const;
     float solveTOI() const;
     float synchronize() const;
-    float emitSignals() const;
 
 private:
     friend class Box2DWorld;
 
     b2World *mWorld;
     float mSynchronize;
-    float mEmitSignals;
 };
 
 
@@ -119,8 +115,8 @@ class Box2DWorld : public QObject, public QQmlParserStatus, b2DestructionListene
     Q_PROPERTY(QPointF gravity READ gravity WRITE setGravity NOTIFY gravityChanged)
     Q_PROPERTY(bool autoClearForces READ autoClearForces WRITE setAutoClearForces NOTIFY autoClearForcesChanged)
     Q_PROPERTY(Box2DProfile *profile READ profile NOTIFY stepped)
+    Q_PROPERTY(Box2DContactListener *contactListener READ contactListener WRITE setContactListener NOTIFY contactListenerChanged)
     Q_PROPERTY(float pixelsPerMeter READ pixelsPerMeter WRITE setPixelsPerMeter NOTIFY pixelsPerMeterChanged)
-    Q_PROPERTY(bool enableContactEvents READ enableContactEvents WRITE setEnableContactEvents NOTIFY enableContactEventsChanged)
 
     Q_INTERFACES(QQmlParserStatus)
 
@@ -148,8 +144,8 @@ public:
 
     Box2DProfile *profile() const;
 
-    bool enableContactEvents() const;
-    void setEnableContactEvents(bool enableContactEvents);
+    Box2DContactListener *contactListener() const;
+    void setContactListener(Box2DContactListener *contactListener);
 
     float pixelsPerMeter() const;
     void setPixelsPerMeter(float pixelsPerMeter);
@@ -182,9 +178,6 @@ public:
                              const QPointF &point2);
 
 signals:
-    void preSolve(Box2DContact * contact);
-    void postSolve(Box2DContact * contact);
-
     void timeStepChanged();
     void velocityIterationsChanged();
     void positionIterationsChanged();
@@ -192,15 +185,12 @@ signals:
     void autoClearForcesChanged();
     void runningChanged();
     void stepped();
-    void enableContactEventsChanged();
+    void contactListenerChanged();
     void pixelsPerMeterChanged();
-
-protected:
-    void enableContactListener(bool enable);
 
 private:
     b2World mWorld;
-    ContactListener *mContactListener;
+    Box2DContactListener *mContactListener;
     float mTimeStep;
     int mVelocityIterations;
     int mPositionIterations;
@@ -209,7 +199,6 @@ private:
     bool mSynchronizing;
     StepDriver *mStepDriver;
     Box2DProfile *mProfile;
-    bool mEnableContactEvents;
     float mPixelsPerMeter;
 };
 
@@ -259,11 +248,6 @@ inline float Box2DProfile::synchronize() const
     return mSynchronize;
 }
 
-inline float Box2DProfile::emitSignals() const
-{
-    return mEmitSignals;
-}
-
 
 /**
  * The amount of time to step through each frame in seconds.
@@ -307,9 +291,9 @@ inline Box2DProfile *Box2DWorld::profile() const
     return mProfile;
 }
 
-inline bool Box2DWorld::enableContactEvents() const
+inline Box2DContactListener *Box2DWorld::contactListener() const
 {
-    return mEnableContactEvents;
+    return mContactListener;
 }
 
 inline float Box2DWorld::pixelsPerMeter() const

--- a/examples/contacts/main.qml
+++ b/examples/contacts/main.qml
@@ -50,13 +50,29 @@ Rectangle {
     World {
         id: physicsWorld
 
-        onPreSolve: {
-            var targetA = contact.fixtureA.getBody().target;
-            var targetB = contact.fixtureB.getBody().target;
-            if (targetA.isBall && contact.fixtureB === topBeltFixture)
-                contact.tangentSpeed = -3.0;
-            else if (targetB.isBall && contact.fixtureA === topBeltFixture)
-                contact.tangentSpeed = 3.0;
+        contactListener: ContactListener {
+            onBeginContact: {
+                if (contact.fixtureA.onBeginContact)
+                    contact.fixtureA.onBeginContact(contact.fixtureB);
+                if (contact.fixtureB.onBeginContact)
+                    contact.fixtureB.onBeginContact(contact.fixtureA);
+            }
+
+            onEndContact: {
+                if (contact.fixtureA.onEndContact)
+                    contact.fixtureA.onEndContact(contact.fixtureB);
+                if (contact.fixtureB.onEndContact)
+                    contact.fixtureB.onEndContact(contact.fixtureA);
+            }
+
+            onPreSolve: {
+                var targetA = contact.fixtureA.getBody().target;
+                var targetB = contact.fixtureB.getBody().target;
+                if (targetA.isBall && contact.fixtureB === topBeltFixture)
+                    contact.tangentSpeed = -3.0;
+                else if (targetB.isBall && contact.fixtureA === topBeltFixture)
+                    contact.tangentSpeed = 3.0;
+            }
         }
     }
 
@@ -264,41 +280,51 @@ Rectangle {
             }
         }
 
-        BoxBody {
+        Body {
             id: flowVertical
-            x: 680
-            y: 60
-            width: 60
-            height: 500
             world: physicsWorld
-            sensor: true
-            onBeginContact: {
-                other.getBody().gravityScale = -2;
+
+            Box {
+                x: 680
+                y: 60
+                width: 60
+                height: 500
+                sensor: true
+
+                function onBeginContact(other) {
+                    other.getBody().gravityScale = -2;
+                }
             }
         }
-        BoxBody {
+
+        Body {
             id: flowHorizontal
-            x: 500
-            y: 10
-            width: 240
-            height: 60
             world: physicsWorld
-            sensor: true
-            onBeginContact: {
-                var body = other.getBody();
-                body.gravityScale = 0.5;
-                body.applyLinearImpulse(Qt.point(-5,0), Qt.point(24,24));
-            }
-            onEndContact: {
-                var body = other.getBody();
-                body.gravityScale = 1;
-                body.applyForce(Qt.point(5,0), Qt.point(24,24));
-                var rect = body.target
-                var index = rect.colorIndex;
-                index ++;
-                rect.colorIndex = index;
-                if ((index + 1) === rect.colors.length)
-                    rect.animateDeletion = true;
+
+            Box {
+                x: 500
+                y: 10
+                width: 240
+                height: 60
+                sensor: true
+
+                function onBeginContact(other) {
+                    var body = other.getBody();
+                    console.log("flowHorizontal.onBeginContact", other, body)
+                    body.gravityScale = 0.5;
+                    body.applyLinearImpulse(Qt.point(-5,0), Qt.point(24,24));
+                }
+
+                function onEndContact(other) {
+                    var body = other.getBody();
+                    body.gravityScale = 1;
+                    body.applyForce(Qt.point(5,0), Qt.point(24,24));
+                    var rect = body.target
+                    var index = rect.colorIndex + 1;
+                    rect.colorIndex = index;
+                    if ((index + 1) === rect.colors.length)
+                        rect.animateDeletion = true;
+                }
             }
         }
 

--- a/examples/gear/main.qml
+++ b/examples/gear/main.qml
@@ -32,7 +32,26 @@ Rectangle {
         }
     }
 
-    World { id: physicsWorld }
+    World {
+        id: physicsWorld
+
+        contactListener: ContactListener {
+            onBeginContact: {
+                checkPaint(contact.fixtureA, contact.fixtureB);
+                checkPaint(contact.fixtureB, contact.fixtureA);
+            }
+
+            function checkPaint(fixtureA, fixtureB) {
+                if (fixtureA.paint) {
+                    var target = fixtureB.getBody().target;
+                    if (target.color === "#EFEFEF") {
+                        target.color = fixtureA.paint
+                        fixtureA.counter++;
+                    }
+                }
+            }
+        }
+    }
 
     PhysicsItem {
         id: ground
@@ -134,12 +153,11 @@ Rectangle {
                 var context = propCanvas.getContext("2d");
                 context.beginPath();
                 var fixtures = prop.fixtures;
-                var count = fixtures.count;
-                for(var i = 0;i < fixtures.length;i ++) {
+                for (var i = 0; i < fixtures.length; i++) {
                     var fixture = fixtures[i];
                     var vertices = fixture.vertices;
                     context.moveTo(vertices[0].x,vertices[0].y);
-                    for(var j = 1;j < vertices.length;j ++) {
+                    for (var j = 1; j < vertices.length; j++) {
                         context.lineTo(vertices[j].x,vertices[j].y);
                     }
                     context.lineTo(vertices[0].x,vertices[0].y);
@@ -315,66 +333,56 @@ Rectangle {
 
     PhysicsItem {
         id: leftSensor
-        x:40
+        x: 40
         y: 360
         width: 360
-        height:20
+        height: 20
         fixtures: Box {
+            id: leftSensorFixture
             width: leftSensor.width
             height: leftSensor.height
             sensor: true
-            onBeginContact: {
-                var target = other.getBody().target
-                if (target.color === "#EFEFEF") {
-                    target.color = "lightgreen"
-                    leftCounter.count++;
-                }
-            }
+            property color paint: "lightgreen"
+            property int counter: 0
         }
     }
 
     PhysicsItem {
         id: rightSensor
-        x:400
+        x: 400
         y: 360
         width: 360
-        height:20
+        height: 20
         fixtures: Box {
+            id: rightSensorFixture
             width: rightSensor.width
             height: rightSensor.height
             sensor: true
-            onBeginContact: {
-                var target = other.getBody().target
-                if (target.color === "#EFEFEF") {
-                    target.color = "orange"
-                    rightCounter.count++;
-                }
-            }
+            property color paint: "orange"
+            property int counter: 0
         }
     }
 
     Text {
         id: leftCounter
-        property int count: 0
-        x:300
+        x: 300
         y: 220
         width: 75
         height: 20
         color: "white"
         horizontalAlignment: Text.AlignHCenter
-        text: leftCounter.count
+        text: leftSensorFixture.counter
     }
 
     Text {
         id: rightCounter
-        property int count: 0
-        x:410
+        x: 410
         y: 220
         width: 75
         height: 20
         color: "white"
         horizontalAlignment: Text.AlignHCenter
-        text: rightCounter.count
+        text: rightSensorFixture.counter
     }
 
     DebugDraw {

--- a/examples/raycast/Wall.qml
+++ b/examples/raycast/Wall.qml
@@ -5,14 +5,11 @@ import "../shared"
 PhysicsItem {
     id: wall
 
-    signal beginContact(Fixture other)
-
     fixtures: Box {
         width: wall.width
         height: wall.height
         friction: 1
         density: 1
-        onBeginContact: parent.beginContact(other)
     }
 
     Image {

--- a/examples/raycast/main.qml
+++ b/examples/raycast/main.qml
@@ -66,6 +66,18 @@ Rectangle {
         onStepped: physicsWorld.rayCast(sensorRay,
                                         sensorRay.point1,
                                         sensorRay.point2)
+
+        contactListener: ContactListener {
+            onBeginContact: {
+                checkBallInBucket(contact.fixtureA, contact.fixtureB);
+                checkBallInBucket(contact.fixtureB, contact.fixtureA);
+            }
+
+            function checkBallInBucket(fixtureA, fixtureB) {
+                if (fixtureA == bucketEdge && fixtureB.isBall)
+                    fixtureB.getBody().target.destroy()
+            }
+        }
     }
 
     Item {
@@ -195,19 +207,16 @@ Rectangle {
                     ]
                 },
                 Edge {
+                    id: bucketEdge
                     vertices: [
                         Qt.point(0,-1),
                         Qt.point(40,-1)
                     ]
                     sensor: true
-                    onBeginContact: {
-                        if (other.isBall)
-                            other.getBody().target.destroy();
-                    }
                 }
             ]
             Canvas {
-                id:bucketCanvas
+                id: bucketCanvas
                 anchors.fill: parent
                 onPaint: {
                     var context = bucketCanvas.getContext("2d");

--- a/examples/shared/BoxBody.qml
+++ b/examples/shared/BoxBody.qml
@@ -18,13 +18,5 @@ Body {
     property alias width: box.width
     property alias height: box.height
 
-    signal beginContact(Fixture other)
-    signal endContact(Fixture other)
-
-    Box {
-        id: box
-
-        onBeginContact: body.beginContact(other)
-        onEndContact: body.endContact(other)
-    }
+    Box { id: box }
 }

--- a/examples/shared/ChainBody.qml
+++ b/examples/shared/ChainBody.qml
@@ -18,13 +18,5 @@ Body {
     property alias prevVertex: chain.prevVertex
     property alias nextVertex: chain.nextVertex
 
-    signal beginContact(Fixture other)
-    signal endContact(Fixture other)
-
-    Chain {
-        id: chain
-
-        onBeginContact: body.beginContact(other)
-        onEndContact: body.endContact(other)
-    }
+    Chain { id: chain }
 }

--- a/examples/shared/CircleBody.qml
+++ b/examples/shared/CircleBody.qml
@@ -17,13 +17,5 @@ Body {
     property alias y: circle.y
     property alias radius: circle.radius
 
-    signal beginContact(Fixture other)
-    signal endContact(Fixture other)
-
-    Circle {
-        id: circle
-
-        onBeginContact: body.beginContact(other)
-        onEndContact: body.endContact(other)
-    }
+    Circle { id: circle }
 }

--- a/examples/shared/EdgeBody.qml
+++ b/examples/shared/EdgeBody.qml
@@ -15,13 +15,5 @@ Body {
 
     property alias vertices: edge.vertices
 
-    signal beginContact(Fixture other)
-    signal endContact(Fixture other)
-
-    Edge {
-        id: edge
-
-        onBeginContact: body.beginContact(other)
-        onEndContact: body.endContact(other)
-    }
+    Edge { id: edge }
 }

--- a/examples/shared/ImageBoxBody.qml
+++ b/examples/shared/ImageBoxBody.qml
@@ -33,9 +33,6 @@ Image {
     property alias collidesWith: box.collidesWith
     property alias groupIndex: box.groupIndex
 
-    signal beginContact(Fixture other)
-    signal endContact(Fixture other)
-
     Body {
         id: boxBody
 
@@ -46,9 +43,6 @@ Image {
 
             width: image.width
             height: image.height
-
-            onBeginContact: image.beginContact(other)
-            onEndContact: image.endContact(other)
         }
     }
 }

--- a/examples/shared/PolygonBody.qml
+++ b/examples/shared/PolygonBody.qml
@@ -15,13 +15,5 @@ Body {
 
     property alias vertices: polygon.vertices
 
-    signal beginContact(Fixture other)
-    signal endContact(Fixture other)
-
-    Polygon {
-        id: polygon
-
-        onBeginContact: body.beginContact(other)
-        onEndContact: body.endContact(other)
-    }
+    Polygon { id: polygon }
 }


### PR DESCRIPTION
To react on begin/end contact events, you now have to set World.contactListener. This avoids the need for two signals for each contact event and makes sure that when not used, this feature causes no overhead.

Also, contact events are no longer delayed. Problems that may happen when changing Box2D state will need to be fixed another way.

This pull request is still a little bit work in progress, since the 'contacts' example is not behaving exactly like it used to for some reason and I still need to investigate this. But the important part is to consider the API is this form.
