### PR TITLE
World::debugDrawTarget property insteed of DebugDraw object

### DIFF
--- a/box2dplugin.cpp
+++ b/box2dplugin.cpp
@@ -29,7 +29,6 @@
 
 #include "box2dworld.h"
 #include "box2dbody.h"
-#include "box2ddebugdraw.h"
 #include "box2dfixture.h"
 #include "box2djoint.h"
 #include "box2ddistancejoint.h"
@@ -69,7 +68,6 @@ void Box2DPlugin::registerTypes(const char *uri)
     qmlRegisterType<Box2DPolygon>(uri, versionMajor, versionMinor, "Polygon");
     qmlRegisterType<Box2DChain>(uri, versionMajor, versionMinor, "Chain");
     qmlRegisterType<Box2DEdge>(uri, versionMajor, versionMinor, "Edge");
-    qmlRegisterType<Box2DDebugDraw>(uri, versionMajor, versionMinor, "DebugDraw");
     qmlRegisterUncreatableType<Box2DJoint>(uri, versionMajor, versionMinor, "Joint",
                                            QStringLiteral("Base type for DistanceJoint, RevoluteJoint etc."));
     qmlRegisterType<Box2DDistanceJoint>(uri, versionMajor, versionMinor, "DistanceJoint");

--- a/box2dworld.cpp
+++ b/box2dworld.cpp
@@ -32,6 +32,7 @@
 #include "box2dfixture.h"
 #include "box2djoint.h"
 #include "box2draycast.h"
+#include "box2ddebugdraw.h"
 
 StepDriver::StepDriver(Box2DWorld *world)
     : QAbstractAnimation(world)
@@ -133,7 +134,8 @@ Box2DWorld::Box2DWorld(QObject *parent) :
     mStepDriver(new StepDriver(this)),
     mProfile(new Box2DProfile(&mWorld, this)),
     mEnableContactEvents(true),
-    mPixelsPerMeter(32.0f)
+    mPixelsPerMeter(32.0f),
+    mDebugDraw(0)
 
 {
     mWorld.SetDestructionListener(this);
@@ -222,6 +224,28 @@ void Box2DWorld::setEnableContactEvents(bool enableContactEvents)
     enableContactListener(mEnableContactEvents);
 
     emit enableContactEventsChanged();
+}
+
+QQuickItem *Box2DWorld::debugDrawTarget()
+{
+    return (mDebugDraw == 0) ? 0 : mDebugDraw->parentItem();
+}
+
+void Box2DWorld::setDebugDrawTarget(QQuickItem *enable)
+{
+    if(enable) {
+        if(mDebugDraw == 0) {
+            mDebugDraw = new Box2DDebugDraw(enable);
+            mDebugDraw->setWorld(this);
+            emit debugDrawTargetChanged();
+        }
+    } else {
+        if(mDebugDraw != 0) {
+            delete mDebugDraw;
+            mDebugDraw = 0;
+            emit debugDrawTargetChanged();
+        }
+    }
 }
 
 void Box2DWorld::enableContactListener(bool enable)

--- a/box2dworld.h
+++ b/box2dworld.h
@@ -40,6 +40,7 @@ class Box2DWorld;
 class Box2DRayCast;
 class ContactListener;
 class StepDriver;
+class Box2DDebugDraw;
 
 /**
  * Small utility class to synchronize the stepping with the framerate.
@@ -121,7 +122,7 @@ class Box2DWorld : public QObject, public QQmlParserStatus, b2DestructionListene
     Q_PROPERTY(Box2DProfile *profile READ profile NOTIFY stepped)
     Q_PROPERTY(float pixelsPerMeter READ pixelsPerMeter WRITE setPixelsPerMeter NOTIFY pixelsPerMeterChanged)
     Q_PROPERTY(bool enableContactEvents READ enableContactEvents WRITE setEnableContactEvents NOTIFY enableContactEventsChanged)
-
+    Q_PROPERTY(QQuickItem *debugDrawTarget READ debugDrawTarget WRITE setDebugDrawTarget NOTIFY debugDrawTargetChanged)
     Q_INTERFACES(QQmlParserStatus)
 
 public:
@@ -150,6 +151,9 @@ public:
 
     bool enableContactEvents() const;
     void setEnableContactEvents(bool enableContactEvents);
+
+    QQuickItem *debugDrawTarget();
+    void setDebugDrawTarget(QQuickItem *debugDrawTarget);
 
     float pixelsPerMeter() const;
     void setPixelsPerMeter(float pixelsPerMeter);
@@ -194,6 +198,7 @@ signals:
     void stepped();
     void enableContactEventsChanged();
     void pixelsPerMeterChanged();
+    void debugDrawTargetChanged();
 
 protected:
     void enableContactListener(bool enable);
@@ -211,6 +216,7 @@ private:
     Box2DProfile *mProfile;
     bool mEnableContactEvents;
     float mPixelsPerMeter;
+    Box2DDebugDraw *mDebugDraw;
 };
 
 


### PR DESCRIPTION
it's just a proposal to usage improvement. Since DebugDraw object is not configurable I suggest to turn it to the suitable property. Like that:
```javascript
World {
    id: physicsWorld
    debugDrawTarget: root
}
```
As for me I would prefer boolean `enableDebugDraw` but it's visual item and must have parent item in `QML` tree.