### PR TITLE
Changed mouseJoint example for touch based platforms

### DIFF
--- a/examples/mouse/main.qml
+++ b/examples/mouse/main.qml
@@ -32,16 +32,12 @@ Rectangle {
         }
 
         onPositionChanged: {
-            if (pressedBody != null) {
-                mouseJoint.target = Qt.point(mouseX, mouseY);
-            }
+            mouseJoint.target = Qt.point(mouseX, mouseY);
         }
 
         onReleased: {
-            if (pressedBody != null) {
-                mouseJoint.bodyB = null;
-                pressedBody = null;
-            }
+            mouseJoint.bodyB = null;
+            pressedBody = null;
         }
     }
 


### PR DESCRIPTION
Changed the mouseJoint example to avoid using hoverEnabled: true, as it is not available on touch based platforms.
Now the mousejoint target position gets updated in the onPositionChanged handler.
