### PR TITLE
Fixed memory leak in contact listener and uninitalized value in box2dbod...

### DIFF
--- a/box2dbody.cpp
+++ b/box2dbody.cpp
@@ -58,6 +58,7 @@ Box2DBody::Box2DBody(QObject *parent) :
     mWorld(0),
     mTarget(0),
     mBody(0),
+    mComponentComplete(false),
     mTransformDirty(false),
     mCreatePending(false)
 {

--- a/box2dworld.cpp
+++ b/box2dworld.cpp
@@ -148,6 +148,7 @@ Box2DWorld::~Box2DWorld()
         toBox2DBody(body)->nullifyBody();
     for (b2Joint *joint = mWorld.GetJointList(); joint; joint = joint->GetNext())
         toBox2DJoint(joint)->nullifyJoint();
+    enableContactListener(false);
 }
 
 void Box2DWorld::setTimeStep(float timeStep)


### PR DESCRIPTION
Hi gals and guys,
valgrind complains about two issues in the latest qml-box2d.
1)
Uninitalized value mComponentComplete in:
<code>
void Box2DBody::createBody()
{
    if (!mWorld)
        return;

```
if (!mComponentComplete) {
```

</code>

2) Memory leak in Contact Listenener:

<code>
void Box2DWorld::componentComplete()
{
    mComponentComplete = true;

```
enableContactListener(mEnableContactEvents);
```

</code>

calls
<code>
mContactListener = new ContactListener(this);
</code>

and memory does  nor get released.

Best regards,
Thomas
