### PR TITLE
Replaced all references to QPointF with QVector2D

### DIFF
--- a/box2dbody.cpp
+++ b/box2dbody.cpp
@@ -165,14 +165,14 @@ void Box2DBody::setAwake(bool awake)
         mBody->SetAwake(awake);
 }
 
-QPointF Box2DBody::linearVelocity() const
+QVector2D Box2DBody::linearVelocity() const
 {
     if (mBody)
         return invertY(mBody->GetLinearVelocity());
     return invertY(mBodyDef.linearVelocity);
 }
 
-void Box2DBody::setLinearVelocity(const QPointF &velocity)
+void Box2DBody::setLinearVelocity(const QVector2D &velocity)
 {
     if (linearVelocity() == velocity)
         return;
@@ -264,7 +264,7 @@ void Box2DBody::createBody()
     }
 
     if (mTarget) {
-        mBodyDef.position = mWorld->toMeters(mTarget->position());
+        mBodyDef.position = mWorld->toMeters(QVector2D(mTarget->position()));
         mBodyDef.angle = toRadians(mTarget->rotation());
     }
     mBody = mWorld->world().CreateBody(&mBodyDef);
@@ -284,7 +284,7 @@ void Box2DBody::synchronize()
 
     if (sync(mBodyDef.position, mBody->GetPosition())) {
         if (mTarget)
-            mTarget->setPosition(mWorld->toPixels(mBodyDef.position));
+            mTarget->setPosition(mWorld->toPixels(mBodyDef.position).toPointF());
         emit positionChanged();
     }
 
@@ -351,14 +351,14 @@ void Box2DBody::updateTransform()
     Q_ASSERT(mBody);
     Q_ASSERT(mTransformDirty);
 
-    mBodyDef.position = mWorld->toMeters(mTarget->position());
+    mBodyDef.position = mWorld->toMeters(QVector2D(mTarget->position()));
     mBodyDef.angle = toRadians(mTarget->rotation());
     mBody->SetTransform(mBodyDef.position, mBodyDef.angle);
     mTransformDirty = false;
 }
 
-void Box2DBody::applyLinearImpulse(const QPointF &impulse,
-                                   const QPointF &point)
+void Box2DBody::applyLinearImpulse(const QVector2D &impulse,
+                                   const QVector2D &point)
 {
     if (mBody)
         mBody->ApplyLinearImpulse(invertY(impulse), mWorld->toMeters(point), true);
@@ -376,27 +376,27 @@ void Box2DBody::applyTorque(qreal torque)
         mBody->ApplyTorque(torque, true);
 }
 
-QPointF Box2DBody::getWorldCenter() const
+QVector2D Box2DBody::getWorldCenter() const
 {
     if (mBody)
         return mWorld->toPixels(mBody->GetWorldCenter());
-    return QPointF();
+    return QVector2D();
 }
 
-QPointF Box2DBody::getLocalCenter() const
+QVector2D Box2DBody::getLocalCenter() const
 {
     if (mBody)
         return mWorld->toPixels(mBody->GetLocalCenter());
-    return QPointF();
+    return QVector2D();
 }
 
-void Box2DBody::applyForce(const QPointF &force, const QPointF &point)
+void Box2DBody::applyForce(const QVector2D &force, const QVector2D &point)
 {
     if (mBody)
         mBody->ApplyForce(invertY(force), mWorld->toMeters(point), true);
 }
 
-void Box2DBody::applyForceToCenter(const QPointF &force)
+void Box2DBody::applyForceToCenter(const QVector2D &force)
 {
     if (mBody)
         mBody->ApplyForceToCenter(invertY(force), true);
@@ -418,46 +418,46 @@ float Box2DBody::getInertia() const
     return mBody ? mBody->GetInertia() : 0.0;
 }
 
-QPointF Box2DBody::toWorldPoint(const QPointF &localPoint) const
+QVector2D Box2DBody::toWorldPoint(const QVector2D &localPoint) const
 {
     if (mBody)
         return mWorld->toPixels(mBody->GetWorldPoint(mWorld->toMeters(localPoint)));
-    return QPointF();
+    return QVector2D();
 }
 
-QPointF Box2DBody::toWorldVector(const QPointF &localVector) const
+QVector2D Box2DBody::toWorldVector(const QVector2D &localVector) const
 {
     if (mBody)
         return mWorld->toPixels(mBody->GetWorldVector(mWorld->toMeters(localVector)));
-    return QPointF();
+    return QVector2D();
 }
 
-QPointF Box2DBody::toLocalPoint(const QPointF &worldPoint) const
+QVector2D Box2DBody::toLocalPoint(const QVector2D &worldPoint) const
 {
     if (mBody)
         return mWorld->toPixels(mBody->GetLocalPoint(mWorld->toMeters(worldPoint)));
-    return QPointF();
+    return QVector2D();
 }
 
-QPointF Box2DBody::toLocalVector(const QPointF &worldVector) const
+QVector2D Box2DBody::toLocalVector(const QVector2D &worldVector) const
 {
     if (mBody)
         return mWorld->toPixels(mBody->GetLocalVector(mWorld->toMeters(worldVector)));
-    return QPointF();
+    return QVector2D();
 }
 
-QPointF Box2DBody::getLinearVelocityFromWorldPoint(const QPointF &point) const
+QVector2D Box2DBody::getLinearVelocityFromWorldPoint(const QVector2D &point) const
 {
     if (mBody)
         return invertY(mBody->GetLinearVelocityFromWorldPoint(mWorld->toMeters(point)));
-    return QPointF();
+    return QVector2D();
 }
 
-QPointF Box2DBody::getLinearVelocityFromLocalPoint(const QPointF &point) const
+QVector2D Box2DBody::getLinearVelocityFromLocalPoint(const QVector2D &point) const
 {
     if (mBody)
         return invertY(mBody->GetLinearVelocityFromLocalPoint(mWorld->toMeters(point)));
-    return QPointF();
+    return QVector2D();
 }
 
 void Box2DBody::markTransformDirty()

--- a/box2dbody.h
+++ b/box2dbody.h
@@ -55,7 +55,7 @@ class Box2DBody : public QObject, public QQmlParserStatus
     Q_PROPERTY(bool fixedRotation READ fixedRotation WRITE setFixedRotation NOTIFY fixedRotationChanged)
     Q_PROPERTY(bool active READ isActive WRITE setActive)
     Q_PROPERTY(bool awake READ isAwake WRITE setAwake)
-    Q_PROPERTY(QPointF linearVelocity READ linearVelocity WRITE setLinearVelocity NOTIFY linearVelocityChanged)
+    Q_PROPERTY(QVector2D linearVelocity READ linearVelocity WRITE setLinearVelocity NOTIFY linearVelocityChanged)
     Q_PROPERTY(float angularVelocity READ angularVelocity WRITE setAngularVelocity NOTIFY angularVelocityChanged)
     Q_PROPERTY(QQmlListProperty<Box2DFixture> fixtures READ fixtures)
     Q_PROPERTY(float gravityScale READ gravityScale WRITE setGravityScale NOTIFY gravityScaleChanged)
@@ -103,8 +103,8 @@ public:
     bool isAwake() const;
     void setAwake(bool awake);
 
-    QPointF linearVelocity() const;
-    void setLinearVelocity(const QPointF &velocity);
+    QVector2D linearVelocity() const;
+    void setLinearVelocity(const QVector2D &velocity);
 
     float angularVelocity() const;
     void setAngularVelocity(float velocity);
@@ -117,22 +117,22 @@ public:
     void synchronize();
     void nullifyBody();
 
-    Q_INVOKABLE void applyForce(const QPointF &force, const QPointF &point);
-    Q_INVOKABLE void applyForceToCenter(const QPointF &force);
+    Q_INVOKABLE void applyForce(const QVector2D &force, const QVector2D &point);
+    Q_INVOKABLE void applyForceToCenter(const QVector2D &force);
     Q_INVOKABLE void applyTorque(qreal torque);
-    Q_INVOKABLE void applyLinearImpulse(const QPointF &impulse, const QPointF &point);
+    Q_INVOKABLE void applyLinearImpulse(const QVector2D &impulse, const QVector2D &point);
     Q_INVOKABLE void applyAngularImpulse(qreal impulse);
-    Q_INVOKABLE QPointF getWorldCenter() const;
-    Q_INVOKABLE QPointF getLocalCenter() const;
+    Q_INVOKABLE QVector2D getWorldCenter() const;
+    Q_INVOKABLE QVector2D getLocalCenter() const;
     Q_INVOKABLE float getMass() const;
     Q_INVOKABLE void resetMassData();
     Q_INVOKABLE float getInertia() const;
-    Q_INVOKABLE QPointF toWorldPoint(const QPointF &localPoint) const;
-    Q_INVOKABLE QPointF toWorldVector(const QPointF &localVector) const;
-    Q_INVOKABLE QPointF toLocalPoint(const QPointF &worldPoint) const;
-    Q_INVOKABLE QPointF toLocalVector(const QPointF &worldVector) const;
-    Q_INVOKABLE QPointF getLinearVelocityFromWorldPoint(const QPointF &point) const;
-    Q_INVOKABLE QPointF getLinearVelocityFromLocalPoint(const QPointF &point) const;
+    Q_INVOKABLE QVector2D toWorldPoint(const QVector2D &localPoint) const;
+    Q_INVOKABLE QVector2D toWorldVector(const QVector2D &localVector) const;
+    Q_INVOKABLE QVector2D toLocalPoint(const QVector2D &worldPoint) const;
+    Q_INVOKABLE QVector2D toLocalVector(const QVector2D &worldVector) const;
+    Q_INVOKABLE QVector2D getLinearVelocityFromWorldPoint(const QVector2D &point) const;
+    Q_INVOKABLE QVector2D getLinearVelocityFromLocalPoint(const QVector2D &point) const;
     Q_INVOKABLE void addFixture(Box2DFixture *fixture);
 
     void classBegin();

--- a/box2ddebugdraw.cpp
+++ b/box2ddebugdraw.cpp
@@ -117,7 +117,7 @@ void DebugDraw::DrawPolygon(const b2Vec2 *vertices,
 
     QSGGeometry::Point2D *points = geometry->vertexDataAsPoint2D();
     for (int i = 0; i < vertexCount; ++i) {
-        QPointF point = mWorld.toPixels(vertices[i]);
+        QVector2D point = mWorld.toPixels(vertices[i]);
         points[i].set(point.x(), point.y());
     }
 
@@ -135,7 +135,7 @@ void DebugDraw::DrawSolidPolygon(const b2Vec2 *vertices,
 
     QSGGeometry::Point2D *points = geometry->vertexDataAsPoint2D();
     for (int i = 0; i < vertexCount; ++i) {
-        QPointF point = mWorld.toPixels(vertices[i]);
+        QVector2D point = mWorld.toPixels(vertices[i]);
         points[i].set(point.x(), point.y());
     }
 
@@ -151,7 +151,7 @@ void DebugDraw::DrawCircle(const b2Vec2 &center,
     geometry->setDrawingMode(GL_LINE_LOOP);
     geometry->setLineWidth(LINE_WIDTH);
 
-    QPointF centerInPixels = mWorld.toPixels(center);
+    QVector2D centerInPixels = mWorld.toPixels(center);
     qreal radiusInPixels = mWorld.toPixels(radius);
 
     QSGGeometry::Point2D *points = geometry->vertexDataAsPoint2D();
@@ -173,8 +173,8 @@ void DebugDraw::DrawSolidCircle(const b2Vec2 &center, float32 radius,
     geometry->setDrawingMode(GL_TRIANGLE_FAN);
     geometry->setLineWidth(LINE_WIDTH);
 
-    QPointF centerInPixels = mWorld.toPixels(center);
-    QPointF axisInPixels = mWorld.toPixels(axis);
+    QVector2D centerInPixels = mWorld.toPixels(center);
+    QVector2D axisInPixels = mWorld.toPixels(axis);
     qreal radiusInPixels = mWorld.toPixels(radius);
     axisInPixels.setX(centerInPixels.x() + radius * axisInPixels.x());
     axisInPixels.setY(centerInPixels.y() + radius * axisInPixels.y());
@@ -201,8 +201,8 @@ void DebugDraw::DrawSegment(const b2Vec2 &p1,
                             const b2Vec2 &p2,
                             const b2Color &color)
 {
-    QPointF p1InPixels = mWorld.toPixels(p1);
-    QPointF p2InPixels = mWorld.toPixels(p2);
+    QVector2D p1InPixels = mWorld.toPixels(p1);
+    QVector2D p2InPixels = mWorld.toPixels(p2);
 
     QSGGeometry *geometry = new QSGGeometry(QSGGeometry::defaultAttributes_Point2D(), 2);
     geometry->setDrawingMode(GL_LINES);
@@ -217,9 +217,9 @@ void DebugDraw::DrawSegment(const b2Vec2 &p1,
 void DebugDraw::DrawTransform(const b2Transform &xf)
 {
 
-    QPointF p1 = mWorld.toPixels(xf.p);
-    QPointF p2 = mWorld.toPixels(xf.q.GetXAxis());
-    p2 = QPointF(p1.x() + mAxisScale * p2.x(),
+    QVector2D p1 = mWorld.toPixels(xf.p);
+    QVector2D p2 = mWorld.toPixels(xf.q.GetXAxis());
+    p2 = QVector2D(p1.x() + mAxisScale * p2.x(),
                  p1.y() + mAxisScale * p2.y());
 
     QSGGeometry *geometryX = new QSGGeometry(QSGGeometry::defaultAttributes_Point2D(), 2);
@@ -230,7 +230,7 @@ void DebugDraw::DrawTransform(const b2Transform &xf)
     createNode(geometryX,Qt::blue);
 
     p2 = mWorld.toPixels(xf.q.GetYAxis());
-    p2 = QPointF(p1.x() + mAxisScale * p2.x(),
+    p2 = QVector2D(p1.x() + mAxisScale * p2.x(),
                  p1.y() + mAxisScale * p2.y());
 
     QSGGeometry *geometryY = new QSGGeometry(QSGGeometry::defaultAttributes_Point2D(), 2);

--- a/box2ddistancejoint.cpp
+++ b/box2ddistancejoint.cpp
@@ -39,7 +39,7 @@ Box2DDistanceJoint::Box2DDistanceJoint(QObject *parent)
 {
 }
 
-void Box2DDistanceJoint::setLocalAnchorA(const QPointF &localAnchorA)
+void Box2DDistanceJoint::setLocalAnchorA(const QVector2D &localAnchorA)
 {
     m_defaultLocalAnchorA = false;
 
@@ -50,7 +50,7 @@ void Box2DDistanceJoint::setLocalAnchorA(const QPointF &localAnchorA)
     emit localAnchorAChanged();
 }
 
-void Box2DDistanceJoint::setLocalAnchorB(const QPointF &localAnchorB)
+void Box2DDistanceJoint::setLocalAnchorB(const QVector2D &localAnchorB)
 {
     m_defaultLocalAnchorB = false;
 
@@ -127,11 +127,11 @@ b2Joint *Box2DDistanceJoint::createJoint()
     return world()->world().CreateJoint(&jointDef);
 }
 
-QPointF Box2DDistanceJoint::getReactionForce(float32 inv_dt) const
+QVector2D Box2DDistanceJoint::getReactionForce(float32 inv_dt) const
 {
     if (distanceJoint())
         return invertY(distanceJoint()->GetReactionForce(inv_dt));
-    return QPointF();
+    return QVector2D();
 }
 
 float Box2DDistanceJoint::getReactionTorque(float32 inv_dt) const

--- a/box2ddistancejoint.h
+++ b/box2ddistancejoint.h
@@ -33,8 +33,8 @@ class Box2DDistanceJoint : public Box2DJoint
 {
     Q_OBJECT
 
-    Q_PROPERTY(QPointF localAnchorA READ localAnchorA WRITE setLocalAnchorA NOTIFY localAnchorAChanged)
-    Q_PROPERTY(QPointF localAnchorB READ localAnchorB WRITE setLocalAnchorB NOTIFY localAnchorBChanged)
+    Q_PROPERTY(QVector2D localAnchorA READ localAnchorA WRITE setLocalAnchorA NOTIFY localAnchorAChanged)
+    Q_PROPERTY(QVector2D localAnchorB READ localAnchorB WRITE setLocalAnchorB NOTIFY localAnchorBChanged)
     Q_PROPERTY(float length READ length WRITE setLength NOTIFY lengthChanged)
     Q_PROPERTY(float frequencyHz READ frequencyHz WRITE setFrequencyHz NOTIFY frequencyHzChanged)
     Q_PROPERTY(float dampingRatio READ dampingRatio WRITE setDampingRatio NOTIFY dampingRatioChanged)
@@ -42,11 +42,11 @@ class Box2DDistanceJoint : public Box2DJoint
 public:
     explicit Box2DDistanceJoint(QObject *parent = 0);
 
-    QPointF localAnchorA() const;
-    void setLocalAnchorA(const QPointF &localAnchorA);
+    QVector2D localAnchorA() const;
+    void setLocalAnchorA(const QVector2D &localAnchorA);
 
-    QPointF localAnchorB() const;
-    void setLocalAnchorB(const QPointF &localAnchorB);
+    QVector2D localAnchorB() const;
+    void setLocalAnchorB(const QVector2D &localAnchorB);
 
     float length() const;
     void setLength(float length);
@@ -59,7 +59,7 @@ public:
 
     b2DistanceJoint *distanceJoint() const;
 
-    Q_INVOKABLE QPointF getReactionForce(float32 inv_dt) const;
+    Q_INVOKABLE QVector2D getReactionForce(float32 inv_dt) const;
     Q_INVOKABLE float getReactionTorque(float32 inv_dt) const;
 
 signals:
@@ -73,8 +73,8 @@ protected:
     b2Joint *createJoint();
 
 private:
-    QPointF m_localAnchorA;
-    QPointF m_localAnchorB;
+    QVector2D m_localAnchorA;
+    QVector2D m_localAnchorB;
     float m_length;
     float m_frequencyHz;
     float m_dampingRatio;
@@ -83,12 +83,12 @@ private:
     bool m_defaultLength;
 };
 
-inline QPointF Box2DDistanceJoint::localAnchorA() const
+inline QVector2D Box2DDistanceJoint::localAnchorA() const
 {
     return m_localAnchorA;
 }
 
-inline QPointF Box2DDistanceJoint::localAnchorB() const
+inline QVector2D Box2DDistanceJoint::localAnchorB() const
 {
     return m_localAnchorB;
 }

--- a/box2dfixture.cpp
+++ b/box2dfixture.cpp
@@ -234,7 +234,7 @@ b2Shape *Box2DBox::createShape()
 {
     const qreal halfWidth = width() * 0.5;
     const qreal halfHeight = height() * 0.5;
-    const QPointF center(x() + halfWidth,
+    const QVector2D center(x() + halfWidth,
                          y() + halfHeight);
 
     b2PolygonShape *shape = new b2PolygonShape;
@@ -280,7 +280,7 @@ b2Shape *Box2DCircle::createShape()
     b2CircleShape *shape = new b2CircleShape;
 
     shape->m_radius = mBody->world()->toMeters(radius());
-    shape->m_p = mBody->world()->toMeters(position() + QPointF(radius(), radius()));
+    shape->m_p = mBody->world()->toMeters(position() + QVector2D(radius(), radius()));
 
     return shape;
 }
@@ -308,7 +308,7 @@ b2Shape *Box2DPolygon::createShape()
     QScopedArrayPointer<b2Vec2> vertices(new b2Vec2[count]);
 
     for (int i = 0; i < count; ++i) {
-        vertices[i] = mBody->world()->toMeters(mVertices.at(i).toPointF());
+        vertices[i] = mBody->world()->toMeters(mVertices.at(i).value<QVector2D>());
 
         if (i > 0) {
             if (b2DistanceSquared(vertices[i - 1], vertices[i]) <= b2_linearSlop * b2_linearSlop) {
@@ -354,7 +354,7 @@ void Box2DChain::setLoop(bool loop)
     emit loopChanged();
 }
 
-void Box2DChain::setPrevVertex(const QPointF &prevVertex)
+void Box2DChain::setPrevVertex(const QVector2D &prevVertex)
 {
     if (mPrevVertexFlag && mPrevVertex == prevVertex)
         return;
@@ -365,7 +365,7 @@ void Box2DChain::setPrevVertex(const QPointF &prevVertex)
     emit prevVertexChanged();
 }
 
-void Box2DChain::setNextVertex(const QPointF &nextVertex)
+void Box2DChain::setNextVertex(const QVector2D &nextVertex)
 {
     if (mNextVertexFlag && mNextVertex == nextVertex)
         return;
@@ -388,7 +388,7 @@ b2Shape *Box2DChain::createShape()
     QScopedArrayPointer<b2Vec2> vertices(new b2Vec2[count]);
 
     for (int i = 0; i < count; ++i) {
-        vertices[i] = mBody->world()->toMeters(mVertices.at(i).toPointF());
+        vertices[i] = mBody->world()->toMeters(mVertices.at(i).value<QVector2D>());
 
         if (i > 0) {
             if (b2DistanceSquared(vertices[i - 1], vertices[i]) <= b2_linearSlop * b2_linearSlop) {
@@ -432,8 +432,8 @@ b2Shape *Box2DEdge::createShape()
         qWarning() << "Edge: Invalid number of vertices:" << count;
         return 0;
     }
-    const b2Vec2 vertex1 = mBody->world()->toMeters(mVertices.at(0).toPointF());
-    const b2Vec2 vertex2 = mBody->world()->toMeters(mVertices.at(1).toPointF());
+    const b2Vec2 vertex1 = mBody->world()->toMeters(mVertices.at(0).value<QVector2D>());
+    const b2Vec2 vertex2 = mBody->world()->toMeters(mVertices.at(1).value<QVector2D>());
     if (b2DistanceSquared(vertex1, vertex2) <= b2_linearSlop * b2_linearSlop) {
         qWarning() << "Edge: vertices are too close together";
         return 0;

--- a/box2dfixture.h
+++ b/box2dfixture.h
@@ -155,7 +155,7 @@ protected:
     b2Shape *createShape();
 
 private:
-    QPointF mPosition;
+    QVector2D mPosition;
     QSizeF mSize;
     qreal mRotation;
 };
@@ -182,7 +182,7 @@ public:
     qreal y() const { return mPosition.y(); }
     void setY(qreal y);
 
-    QPointF position() const { return mPosition; }
+    QVector2D position() const { return mPosition; }
 
     float radius() const { return mRadius; }
     void setRadius(float radius);
@@ -196,7 +196,7 @@ protected:
     b2Shape *createShape();
 
 private:
-    QPointF mPosition;
+    QVector2D mPosition;
     float mRadius;
 };
 
@@ -232,8 +232,8 @@ class Box2DChain : public Box2DFixture
 
     Q_PROPERTY(QVariantList vertices READ vertices WRITE setVertices NOTIFY verticesChanged)
     Q_PROPERTY(bool loop READ loop WRITE setLoop NOTIFY loopChanged)
-    Q_PROPERTY(QPointF prevVertex READ prevVertex WRITE setPrevVertex NOTIFY prevVertexChanged)
-    Q_PROPERTY(QPointF nextVertex READ nextVertex WRITE setNextVertex NOTIFY nextVertexChanged)
+    Q_PROPERTY(QVector2D prevVertex READ prevVertex WRITE setPrevVertex NOTIFY prevVertexChanged)
+    Q_PROPERTY(QVector2D nextVertex READ nextVertex WRITE setNextVertex NOTIFY nextVertexChanged)
 
 public:
     explicit Box2DChain(QQuickItem *parent = 0);
@@ -244,11 +244,11 @@ public:
     bool loop() const { return mLoop; }
     void setLoop(bool loop);
 
-    QPointF prevVertex() const { return mPrevVertex; }
-    void setPrevVertex(const QPointF &prevVertex);
+    QVector2D prevVertex() const { return mPrevVertex; }
+    void setPrevVertex(const QVector2D &prevVertex);
 
-    QPointF nextVertex() const { return mNextVertex; }
-    void setNextVertex(const QPointF &nextVertex);
+    QVector2D nextVertex() const { return mNextVertex; }
+    void setNextVertex(const QVector2D &nextVertex);
 
 signals:
     void verticesChanged();
@@ -261,8 +261,8 @@ protected:
 
 private:
     QVariantList mVertices;
-    QPointF mPrevVertex;
-    QPointF mNextVertex;
+    QVector2D mPrevVertex;
+    QVector2D mNextVertex;
     bool mLoop;
     bool mPrevVertexFlag;
     bool mNextVertexFlag;

--- a/box2dfrictionjoint.cpp
+++ b/box2dfrictionjoint.cpp
@@ -37,7 +37,7 @@ Box2DFrictionJoint::Box2DFrictionJoint(QObject *parent)
 {
 }
 
-void Box2DFrictionJoint::setLocalAnchorA(const QPointF &localAnchorA)
+void Box2DFrictionJoint::setLocalAnchorA(const QVector2D &localAnchorA)
 {
     m_defaultLocalAnchorA = false;
 
@@ -48,7 +48,7 @@ void Box2DFrictionJoint::setLocalAnchorA(const QPointF &localAnchorA)
     emit localAnchorAChanged();
 }
 
-void Box2DFrictionJoint::setLocalAnchorB(const QPointF &localAnchorB)
+void Box2DFrictionJoint::setLocalAnchorB(const QVector2D &localAnchorB)
 {
     m_defaultLocalAnchorB = false;
 
@@ -114,11 +114,11 @@ b2Joint *Box2DFrictionJoint::createJoint()
     return world()->world().CreateJoint(&jointDef);
 }
 
-QPointF Box2DFrictionJoint::getReactionForce(float32 inv_dt) const
+QVector2D Box2DFrictionJoint::getReactionForce(float32 inv_dt) const
 {
     if (frictionJoint())
         return invertY(frictionJoint()->GetReactionForce(inv_dt));
-    return QPointF();
+    return QVector2D();
 }
 
 float Box2DFrictionJoint::getReactionTorque(float32 inv_dt) const

--- a/box2dfrictionjoint.h
+++ b/box2dfrictionjoint.h
@@ -33,19 +33,19 @@ class Box2DFrictionJoint : public Box2DJoint
 {
     Q_OBJECT
 
-    Q_PROPERTY(QPointF localAnchorA READ localAnchorA WRITE setLocalAnchorA NOTIFY localAnchorAChanged)
-    Q_PROPERTY(QPointF localAnchorB READ localAnchorB WRITE setLocalAnchorB NOTIFY localAnchorBChanged)
+    Q_PROPERTY(QVector2D localAnchorA READ localAnchorA WRITE setLocalAnchorA NOTIFY localAnchorAChanged)
+    Q_PROPERTY(QVector2D localAnchorB READ localAnchorB WRITE setLocalAnchorB NOTIFY localAnchorBChanged)
     Q_PROPERTY(float maxForce READ maxForce WRITE setMaxForce NOTIFY maxForceChanged)
     Q_PROPERTY(float maxTorque READ maxTorque WRITE setMaxTorque NOTIFY maxTorqueChanged)
 
 public:
     explicit Box2DFrictionJoint(QObject *parent = 0);
 
-    QPointF localAnchorA() const;
-    void setLocalAnchorA(const QPointF &localAnchorA);
+    QVector2D localAnchorA() const;
+    void setLocalAnchorA(const QVector2D &localAnchorA);
 
-    QPointF localAnchorB() const;
-    void setLocalAnchorB(const QPointF &localAnchorB);
+    QVector2D localAnchorB() const;
+    void setLocalAnchorB(const QVector2D &localAnchorB);
 
     float maxForce() const;
     void setMaxForce(float maxForce);
@@ -55,7 +55,7 @@ public:
 
     b2FrictionJoint *frictionJoint() const;
 
-    Q_INVOKABLE QPointF getReactionForce(float32 inv_dt) const;
+    Q_INVOKABLE QVector2D getReactionForce(float32 inv_dt) const;
     Q_INVOKABLE float getReactionTorque(float32 inv_dt) const;
 
 signals:
@@ -68,20 +68,20 @@ protected:
     b2Joint *createJoint();
 
 private:
-    QPointF m_localAnchorA;
-    QPointF m_localAnchorB;
+    QVector2D m_localAnchorA;
+    QVector2D m_localAnchorB;
     float m_maxForce;
     float m_maxTorque;
     bool m_defaultLocalAnchorA;
     bool m_defaultLocalAnchorB;
 };
 
-inline QPointF Box2DFrictionJoint::localAnchorA() const
+inline QVector2D Box2DFrictionJoint::localAnchorA() const
 {
     return m_localAnchorA;
 }
 
-inline QPointF Box2DFrictionJoint::localAnchorB() const
+inline QVector2D Box2DFrictionJoint::localAnchorB() const
 {
     return m_localAnchorB;
 }

--- a/box2djoint.h
+++ b/box2djoint.h
@@ -28,7 +28,7 @@
 #define BOX2DJOINT_H
 
 #include <QObject>
-#include <QPointF>
+#include <QVector2D>
 #include <QQmlParserStatus>
 
 #include <Box2D.h>

--- a/box2dmotorjoint.cpp
+++ b/box2dmotorjoint.cpp
@@ -40,7 +40,7 @@ Box2DMotorJoint::Box2DMotorJoint(QObject *parent)
 {
 }
 
-void Box2DMotorJoint::setLinearOffset(const QPointF &linearOffset)
+void Box2DMotorJoint::setLinearOffset(const QVector2D &linearOffset)
 {
     m_defaultLinearOffset = false;
 

--- a/box2dmotorjoint.h
+++ b/box2dmotorjoint.h
@@ -34,7 +34,7 @@ class Box2DMotorJoint : public Box2DJoint
 {
     Q_OBJECT
 
-    Q_PROPERTY(QPointF linearOffset READ linearOffset WRITE setLinearOffset NOTIFY linearOffsetChanged)
+    Q_PROPERTY(QVector2D linearOffset READ linearOffset WRITE setLinearOffset NOTIFY linearOffsetChanged)
     Q_PROPERTY(float angularOffset READ angularOffset WRITE setAngularOffset NOTIFY angularOffsetChanged)
     Q_PROPERTY(float maxForce READ maxForce WRITE setMaxForce NOTIFY maxForceChanged)
     Q_PROPERTY(float maxTorque READ maxTorque WRITE setMaxTorque NOTIFY maxTorqueChanged)
@@ -43,8 +43,8 @@ class Box2DMotorJoint : public Box2DJoint
 public:
     explicit Box2DMotorJoint(QObject *parent = 0);
 
-    QPointF linearOffset() const;
-    void setLinearOffset(const QPointF & linearOffset);
+    QVector2D linearOffset() const;
+    void setLinearOffset(const QVector2D & linearOffset);
 
     float angularOffset() const;
     void setAngularOffset(float angularOffset);
@@ -71,7 +71,7 @@ protected:
     b2Joint *createJoint();
 
 private:
-    QPointF m_linearOffset;
+    QVector2D m_linearOffset;
     float m_angularOffset;
     float m_maxForce;
     float m_maxTorque;
@@ -80,7 +80,7 @@ private:
     bool m_defaultAngularOffset;
 };
 
-inline QPointF Box2DMotorJoint::linearOffset() const
+inline QVector2D Box2DMotorJoint::linearOffset() const
 {
     return m_linearOffset;
 }

--- a/box2dmousejoint.cpp
+++ b/box2dmousejoint.cpp
@@ -69,7 +69,7 @@ void Box2DMouseJoint::setMaxForce(float maxForce)
     emit maxForceChanged();
 }
 
-void Box2DMouseJoint::setTarget(const QPointF &target)
+void Box2DMouseJoint::setTarget(const QVector2D &target)
 {
     if (m_target == target)
         return;
@@ -93,11 +93,11 @@ b2Joint *Box2DMouseJoint::createJoint()
     return world()->world().CreateJoint(&jointDef);
 }
 
-QPointF Box2DMouseJoint::getReactionForce(float32 inv_dt) const
+QVector2D Box2DMouseJoint::getReactionForce(float32 inv_dt) const
 {
     if (mouseJoint())
         return invertY(mouseJoint()->GetReactionForce(inv_dt));
-    return QPointF();
+    return QVector2D();
 }
 
 float Box2DMouseJoint::getReactionTorque(float32 inv_dt) const

--- a/box2dmousejoint.h
+++ b/box2dmousejoint.h
@@ -33,7 +33,7 @@ class Box2DMouseJoint : public Box2DJoint
 {
     Q_OBJECT
 
-    Q_PROPERTY(QPointF target READ target WRITE setTarget NOTIFY targetChanged)
+    Q_PROPERTY(QVector2D target READ target WRITE setTarget NOTIFY targetChanged)
     Q_PROPERTY(float maxForce READ maxForce WRITE setMaxForce NOTIFY maxForceChanged)
     Q_PROPERTY(float frequencyHz READ frequencyHz WRITE setFrequencyHz NOTIFY frequencyHzChanged)
     Q_PROPERTY(float dampingRatio READ dampingRatio WRITE setDampingRatio NOTIFY dampingRatioChanged)
@@ -50,10 +50,10 @@ public:
     float maxForce() const;
     void setMaxForce(float maxForce);
 
-    QPointF target() const;
-    void setTarget(const QPointF &target);
+    QVector2D target() const;
+    void setTarget(const QVector2D &target);
 
-    Q_INVOKABLE QPointF getReactionForce(float32 inv_dt) const;
+    Q_INVOKABLE QVector2D getReactionForce(float32 inv_dt) const;
     Q_INVOKABLE float getReactionTorque(float32 inv_dt) const;
 
     b2MouseJoint *mouseJoint() const;
@@ -68,7 +68,7 @@ protected:
     b2Joint *createJoint();
 
 private:
-    QPointF m_target;
+    QVector2D m_target;
     float m_maxForce;
     float m_frequencyHz;
     float m_dampingRatio;
@@ -89,7 +89,7 @@ inline float Box2DMouseJoint::maxForce() const
     return m_maxForce;
 }
 
-inline QPointF Box2DMouseJoint::target() const
+inline QVector2D Box2DMouseJoint::target() const
 {
     return m_target;
 }

--- a/box2dprismaticjoint.cpp
+++ b/box2dprismaticjoint.cpp
@@ -43,7 +43,7 @@ Box2DPrismaticJoint::Box2DPrismaticJoint(QObject *parent)
 {
 }
 
-void Box2DPrismaticJoint::setLocalAnchorA(const QPointF &localAnchorA)
+void Box2DPrismaticJoint::setLocalAnchorA(const QVector2D &localAnchorA)
 {
     m_defaultLocalAnchorA = false;
 
@@ -54,7 +54,7 @@ void Box2DPrismaticJoint::setLocalAnchorA(const QPointF &localAnchorA)
     emit localAnchorAChanged();
 }
 
-void Box2DPrismaticJoint::setLocalAnchorB(const QPointF &localAnchorB)
+void Box2DPrismaticJoint::setLocalAnchorB(const QVector2D &localAnchorB)
 {
     m_defaultLocalAnchorB = false;
 
@@ -65,7 +65,7 @@ void Box2DPrismaticJoint::setLocalAnchorB(const QPointF &localAnchorB)
     emit localAnchorBChanged();
 }
 
-void Box2DPrismaticJoint::setLocalAxisA(const QPointF &localAxisA)
+void Box2DPrismaticJoint::setLocalAxisA(const QVector2D &localAxisA)
 {
     if (m_localAxisA == localAxisA)
         return;

--- a/box2dprismaticjoint.h
+++ b/box2dprismaticjoint.h
@@ -33,9 +33,9 @@ class Box2DPrismaticJoint : public Box2DJoint
 {
     Q_OBJECT
 
-    Q_PROPERTY(QPointF localAnchorA READ localAnchorA WRITE setLocalAnchorA NOTIFY localAnchorAChanged)
-    Q_PROPERTY(QPointF localAnchorB READ localAnchorB WRITE setLocalAnchorB NOTIFY localAnchorBChanged)
-    Q_PROPERTY(QPointF localAxisA READ localAxisA WRITE setLocalAxisA NOTIFY localAxisAChanged)
+    Q_PROPERTY(QVector2D localAnchorA READ localAnchorA WRITE setLocalAnchorA NOTIFY localAnchorAChanged)
+    Q_PROPERTY(QVector2D localAnchorB READ localAnchorB WRITE setLocalAnchorB NOTIFY localAnchorBChanged)
+    Q_PROPERTY(QVector2D localAxisA READ localAxisA WRITE setLocalAxisA NOTIFY localAxisAChanged)
     Q_PROPERTY(float referenceAngle READ referenceAngle WRITE setReferenceAngle NOTIFY referenceAngleChanged)
     Q_PROPERTY(bool enableLimit READ enableLimit WRITE setEnableLimit NOTIFY enableLimitChanged)
     Q_PROPERTY(float lowerTranslation READ lowerTranslation WRITE setLowerTranslation NOTIFY lowerTranslationChanged)
@@ -47,14 +47,14 @@ class Box2DPrismaticJoint : public Box2DJoint
 public:
     explicit Box2DPrismaticJoint(QObject *parent = 0);
 
-    QPointF localAnchorA() const;
-    void setLocalAnchorA(const QPointF &localAnchorA);
+    QVector2D localAnchorA() const;
+    void setLocalAnchorA(const QVector2D &localAnchorA);
 
-    QPointF localAnchorB() const;
-    void setLocalAnchorB(const QPointF &localAnchorB);
+    QVector2D localAnchorB() const;
+    void setLocalAnchorB(const QVector2D &localAnchorB);
 
-    QPointF localAxisA() const;
-    void setLocalAxisA(const QPointF &localAxisA);
+    QVector2D localAxisA() const;
+    void setLocalAxisA(const QVector2D &localAxisA);
 
     float referenceAngle() const;
     void setReferenceAngle(float referenceAngle);
@@ -98,9 +98,9 @@ protected:
     b2Joint *createJoint();
 
 private:
-    QPointF m_localAnchorA;
-    QPointF m_localAnchorB;
-    QPointF m_localAxisA;
+    QVector2D m_localAnchorA;
+    QVector2D m_localAnchorB;
+    QVector2D m_localAxisA;
     float m_referenceAngle;
     bool m_enableLimit;
     float m_lowerTranslation;
@@ -114,17 +114,17 @@ private:
     bool m_defaultReferenceAngle;
 };
 
-inline QPointF Box2DPrismaticJoint::localAnchorA() const
+inline QVector2D Box2DPrismaticJoint::localAnchorA() const
 {
     return m_localAnchorA;
 }
 
-inline QPointF Box2DPrismaticJoint::localAnchorB() const
+inline QVector2D Box2DPrismaticJoint::localAnchorB() const
 {
     return m_localAnchorB;
 }
 
-inline QPointF Box2DPrismaticJoint::localAxisA() const
+inline QVector2D Box2DPrismaticJoint::localAxisA() const
 {
     return m_localAxisA;
 }

--- a/box2dpulleyjoint.cpp
+++ b/box2dpulleyjoint.cpp
@@ -41,7 +41,7 @@ Box2DPulleyJoint::Box2DPulleyJoint(QObject *parent)
     setCollideConnected(true);
 }
 
-void Box2DPulleyJoint::setGroundAnchorA(const QPointF &groundAnchorA)
+void Box2DPulleyJoint::setGroundAnchorA(const QVector2D &groundAnchorA)
 {
     if (m_groundAnchorA == groundAnchorA)
         return;
@@ -50,7 +50,7 @@ void Box2DPulleyJoint::setGroundAnchorA(const QPointF &groundAnchorA)
     emit groundAnchorAChanged();
 }
 
-void Box2DPulleyJoint::setGroundAnchorB(const QPointF &groundAnchorB)
+void Box2DPulleyJoint::setGroundAnchorB(const QVector2D &groundAnchorB)
 {
     if (m_groundAnchorB == groundAnchorB)
         return;
@@ -59,7 +59,7 @@ void Box2DPulleyJoint::setGroundAnchorB(const QPointF &groundAnchorB)
     emit groundAnchorBChanged();
 }
 
-void Box2DPulleyJoint::setLocalAnchorA(const QPointF &localAnchorA)
+void Box2DPulleyJoint::setLocalAnchorA(const QVector2D &localAnchorA)
 {
     m_defaultLocalAnchorA = false;
 
@@ -70,7 +70,7 @@ void Box2DPulleyJoint::setLocalAnchorA(const QPointF &localAnchorA)
     emit localAnchorAChanged();
 }
 
-void Box2DPulleyJoint::setLocalAnchorB(const QPointF &localAnchorB)
+void Box2DPulleyJoint::setLocalAnchorB(const QVector2D &localAnchorB)
 {
     m_defaultLocalAnchorB = false;
 
@@ -170,11 +170,11 @@ float Box2DPulleyJoint::getCurrentLengthB() const
     return lengthB();
 }
 
-QPointF Box2DPulleyJoint::getReactionForce(float32 inv_dt) const
+QVector2D Box2DPulleyJoint::getReactionForce(float32 inv_dt) const
 {
     if (pulleyJoint())
         return invertY(pulleyJoint()->GetReactionForce(inv_dt));
-    return QPointF();
+    return QVector2D();
 }
 
 float Box2DPulleyJoint::getReactionTorque(float32 inv_dt) const

--- a/box2dpulleyjoint.h
+++ b/box2dpulleyjoint.h
@@ -33,10 +33,10 @@ class Box2DPulleyJoint : public Box2DJoint
 {
     Q_OBJECT
 
-    Q_PROPERTY(QPointF groundAnchorA READ groundAnchorA WRITE setGroundAnchorA NOTIFY groundAnchorAChanged)
-    Q_PROPERTY(QPointF groundAnchorB READ groundAnchorB WRITE setGroundAnchorB NOTIFY groundAnchorBChanged)
-    Q_PROPERTY(QPointF localAnchorA READ localAnchorA WRITE setLocalAnchorA NOTIFY localAnchorAChanged)
-    Q_PROPERTY(QPointF localAnchorB READ localAnchorB WRITE setLocalAnchorB NOTIFY localAnchorBChanged)
+    Q_PROPERTY(QVector2D groundAnchorA READ groundAnchorA WRITE setGroundAnchorA NOTIFY groundAnchorAChanged)
+    Q_PROPERTY(QVector2D groundAnchorB READ groundAnchorB WRITE setGroundAnchorB NOTIFY groundAnchorBChanged)
+    Q_PROPERTY(QVector2D localAnchorA READ localAnchorA WRITE setLocalAnchorA NOTIFY localAnchorAChanged)
+    Q_PROPERTY(QVector2D localAnchorB READ localAnchorB WRITE setLocalAnchorB NOTIFY localAnchorBChanged)
     Q_PROPERTY(float lengthA READ lengthA WRITE setLengthA NOTIFY lengthAChanged)
     Q_PROPERTY(float lengthB READ lengthB WRITE setLengthB NOTIFY lengthBChanged)
     Q_PROPERTY(float ratio READ ratio WRITE setRatio NOTIFY ratioChanged)
@@ -44,17 +44,17 @@ class Box2DPulleyJoint : public Box2DJoint
 public:
     explicit Box2DPulleyJoint(QObject *parent = 0);
 
-    QPointF groundAnchorA() const;
-    void setGroundAnchorA(const QPointF &groundAnchorA);
+    QVector2D groundAnchorA() const;
+    void setGroundAnchorA(const QVector2D &groundAnchorA);
 
-    QPointF groundAnchorB() const;
-    void setGroundAnchorB(const QPointF &groundAnchorB);
+    QVector2D groundAnchorB() const;
+    void setGroundAnchorB(const QVector2D &groundAnchorB);
 
-    QPointF localAnchorA() const;
-    void setLocalAnchorA(const QPointF &localAnchorA);
+    QVector2D localAnchorA() const;
+    void setLocalAnchorA(const QVector2D &localAnchorA);
 
-    QPointF localAnchorB() const;
-    void setLocalAnchorB(const QPointF &localAnchorB);
+    QVector2D localAnchorB() const;
+    void setLocalAnchorB(const QVector2D &localAnchorB);
 
     float lengthA() const;
     void setLengthA(float lengthA);
@@ -69,7 +69,7 @@ public:
 
     Q_INVOKABLE float getCurrentLengthA() const;
     Q_INVOKABLE float getCurrentLengthB() const;
-    Q_INVOKABLE QPointF getReactionForce(float32 inv_dt) const;
+    Q_INVOKABLE QVector2D getReactionForce(float32 inv_dt) const;
     Q_INVOKABLE float getReactionTorque(float32 inv_dt) const;
 
 signals:
@@ -85,10 +85,10 @@ protected:
     b2Joint *createJoint();
 
 private:
-    QPointF m_groundAnchorA;
-    QPointF m_groundAnchorB;
-    QPointF m_localAnchorA;
-    QPointF m_localAnchorB;
+    QVector2D m_groundAnchorA;
+    QVector2D m_groundAnchorB;
+    QVector2D m_localAnchorA;
+    QVector2D m_localAnchorB;
     float m_lengthA;
     float m_lengthB;
     float m_ratio;
@@ -99,22 +99,22 @@ private:
     bool m_defaultLengthB;
 };
 
-inline QPointF Box2DPulleyJoint::groundAnchorA() const
+inline QVector2D Box2DPulleyJoint::groundAnchorA() const
 {
     return m_groundAnchorA;
 }
 
-inline QPointF Box2DPulleyJoint::groundAnchorB() const
+inline QVector2D Box2DPulleyJoint::groundAnchorB() const
 {
     return m_groundAnchorB;
 }
 
-inline QPointF Box2DPulleyJoint::localAnchorA() const
+inline QVector2D Box2DPulleyJoint::localAnchorA() const
 {
     return m_localAnchorA;
 }
 
-inline QPointF Box2DPulleyJoint::localAnchorB() const
+inline QVector2D Box2DPulleyJoint::localAnchorB() const
 {
     return m_localAnchorB;
 }

--- a/box2draycast.h
+++ b/box2draycast.h
@@ -27,7 +27,7 @@
 #define BOX2DRAYCAST_H
 
 #include <QObject>
-#include <QPointF>
+#include <QVector2D>
 
 #include <Box2D.h>
 
@@ -52,8 +52,8 @@ public:
 
 signals:
     void fixtureReported(Box2DFixture *fixture,
-                         const QPointF &point,
-                         const QPointF &normal,
+                         const QVector2D &point,
+                         const QVector2D &normal,
                          qreal fraction);
 
 private:

--- a/box2drevolutejoint.cpp
+++ b/box2drevolutejoint.cpp
@@ -44,7 +44,7 @@ Box2DRevoluteJoint::Box2DRevoluteJoint(QObject *parent)
 {
 }
 
-void Box2DRevoluteJoint::setLocalAnchorA(const QPointF &localAnchorA)
+void Box2DRevoluteJoint::setLocalAnchorA(const QVector2D &localAnchorA)
 {
     m_defaultLocalAnchorA = false;
 
@@ -55,7 +55,7 @@ void Box2DRevoluteJoint::setLocalAnchorA(const QPointF &localAnchorA)
     emit localAnchorAChanged();
 }
 
-void Box2DRevoluteJoint::setLocalAnchorB(const QPointF &localAnchorB)
+void Box2DRevoluteJoint::setLocalAnchorB(const QVector2D &localAnchorB)
 {
     m_defaultLocalAnchorB = false;
 

--- a/box2drevolutejoint.h
+++ b/box2drevolutejoint.h
@@ -34,8 +34,8 @@ class Box2DRevoluteJoint : public Box2DJoint
 {
     Q_OBJECT
 
-    Q_PROPERTY(QPointF localAnchorA READ localAnchorA WRITE setLocalAnchorA NOTIFY localAnchorAChanged)
-    Q_PROPERTY(QPointF localAnchorB READ localAnchorB WRITE setLocalAnchorB NOTIFY localAnchorBChanged)
+    Q_PROPERTY(QVector2D localAnchorA READ localAnchorA WRITE setLocalAnchorA NOTIFY localAnchorAChanged)
+    Q_PROPERTY(QVector2D localAnchorB READ localAnchorB WRITE setLocalAnchorB NOTIFY localAnchorBChanged)
     Q_PROPERTY(float referenceAngle READ referenceAngle WRITE setReferenceAngle NOTIFY referenceAngleChanged)
     Q_PROPERTY(bool enableLimit READ enableLimit WRITE setEnableLimit NOTIFY enableLimitChanged)
     Q_PROPERTY(float lowerAngle READ lowerAngle WRITE setLowerAngle NOTIFY lowerAngleChanged)
@@ -47,11 +47,11 @@ class Box2DRevoluteJoint : public Box2DJoint
 public:
     explicit Box2DRevoluteJoint(QObject *parent = 0);
 
-    QPointF localAnchorA() const;
-    void setLocalAnchorA(const QPointF &localAnchorA);
+    QVector2D localAnchorA() const;
+    void setLocalAnchorA(const QVector2D &localAnchorA);
 
-    QPointF localAnchorB() const;
-    void setLocalAnchorB(const QPointF &localAnchorB);
+    QVector2D localAnchorB() const;
+    void setLocalAnchorB(const QVector2D &localAnchorB);
 
     float referenceAngle() const;
     void setReferenceAngle(float referenceAngle);
@@ -94,8 +94,8 @@ protected:
     b2Joint *createJoint();
 
 private:
-    QPointF m_localAnchorA;
-    QPointF m_localAnchorB;
+    QVector2D m_localAnchorA;
+    QVector2D m_localAnchorB;
     float m_referenceAngle;
     bool m_enableLimit;
     float m_lowerAngle;
@@ -108,12 +108,12 @@ private:
     bool m_defaultReferenceAngle;
 };
 
-inline QPointF Box2DRevoluteJoint::localAnchorA() const
+inline QVector2D Box2DRevoluteJoint::localAnchorA() const
 {
     return m_localAnchorA;
 }
 
-inline QPointF Box2DRevoluteJoint::localAnchorB() const
+inline QVector2D Box2DRevoluteJoint::localAnchorB() const
 {
     return m_localAnchorB;
 }

--- a/box2dropejoint.cpp
+++ b/box2dropejoint.cpp
@@ -36,7 +36,7 @@ Box2DRopeJoint::Box2DRopeJoint(QObject *parent)
 {
 }
 
-void Box2DRopeJoint::setLocalAnchorA(const QPointF &localAnchorA)
+void Box2DRopeJoint::setLocalAnchorA(const QVector2D &localAnchorA)
 {
     m_defaultLocalAnchorA = false;
 
@@ -47,7 +47,7 @@ void Box2DRopeJoint::setLocalAnchorA(const QPointF &localAnchorA)
     emit localAnchorAChanged();
 }
 
-void Box2DRopeJoint::setLocalAnchorB(const QPointF &localAnchorB)
+void Box2DRopeJoint::setLocalAnchorB(const QVector2D &localAnchorB)
 {
     m_defaultLocalAnchorB = false;
 
@@ -99,11 +99,11 @@ b2Joint *Box2DRopeJoint::createJoint()
     return world()->world().CreateJoint(&jointDef);
 }
 
-QPointF Box2DRopeJoint::getReactionForce(float32 inv_dt) const
+QVector2D Box2DRopeJoint::getReactionForce(float32 inv_dt) const
 {
     if (ropeJoint())
         return invertY(ropeJoint()->GetReactionForce(inv_dt));
-    return QPointF();
+    return QVector2D();
 }
 
 float Box2DRopeJoint::getReactionTorque(float32 inv_dt) const

--- a/box2dropejoint.h
+++ b/box2dropejoint.h
@@ -37,25 +37,25 @@ class Box2DRopeJoint : public Box2DJoint
 {
     Q_OBJECT
 
-    Q_PROPERTY(QPointF localAnchorA READ localAnchorA WRITE setLocalAnchorA NOTIFY localAnchorAChanged)
-    Q_PROPERTY(QPointF localAnchorB READ localAnchorB WRITE setLocalAnchorB NOTIFY localAnchorBChanged)
+    Q_PROPERTY(QVector2D localAnchorA READ localAnchorA WRITE setLocalAnchorA NOTIFY localAnchorAChanged)
+    Q_PROPERTY(QVector2D localAnchorB READ localAnchorB WRITE setLocalAnchorB NOTIFY localAnchorBChanged)
     Q_PROPERTY(float maxLength READ maxLength WRITE setMaxLength NOTIFY maxLengthChanged)
 
 public:
     explicit Box2DRopeJoint(QObject *parent = 0);
 
-    QPointF localAnchorA() const;
-    void setLocalAnchorA(const QPointF &localAnchorA);
+    QVector2D localAnchorA() const;
+    void setLocalAnchorA(const QVector2D &localAnchorA);
 
-    QPointF localAnchorB() const;
-    void setLocalAnchorB(const QPointF &localAnchorB);
+    QVector2D localAnchorB() const;
+    void setLocalAnchorB(const QVector2D &localAnchorB);
 
     float maxLength() const;
     void setMaxLength(float maxLength);
 
     b2RopeJoint *ropeJoint() const;
 
-    Q_INVOKABLE QPointF getReactionForce(float32 inv_dt) const;
+    Q_INVOKABLE QVector2D getReactionForce(float32 inv_dt) const;
     Q_INVOKABLE float getReactionTorque(float32 inv_dt) const;
 
 signals:
@@ -67,20 +67,20 @@ protected:
     b2Joint *createJoint();
 
 private:
-    QPointF m_localAnchorA;
-    QPointF m_localAnchorB;
+    QVector2D m_localAnchorA;
+    QVector2D m_localAnchorB;
     float m_maxLength;
 
     bool m_defaultLocalAnchorA;
     bool m_defaultLocalAnchorB;
 };
 
-inline QPointF Box2DRopeJoint::localAnchorA() const
+inline QVector2D Box2DRopeJoint::localAnchorA() const
 {
     return m_localAnchorA;
 }
 
-inline QPointF Box2DRopeJoint::localAnchorB() const
+inline QVector2D Box2DRopeJoint::localAnchorB() const
 {
     return m_localAnchorB;
 }

--- a/box2dweldjoint.cpp
+++ b/box2dweldjoint.cpp
@@ -39,7 +39,7 @@ Box2DWeldJoint::Box2DWeldJoint(QObject *parent)
 {
 }
 
-void Box2DWeldJoint::setLocalAnchorA(const QPointF &localAnchorA)
+void Box2DWeldJoint::setLocalAnchorA(const QVector2D &localAnchorA)
 {
     m_defaultLocalAnchorA = false;
 
@@ -50,7 +50,7 @@ void Box2DWeldJoint::setLocalAnchorA(const QPointF &localAnchorA)
     emit localAnchorAChanged();
 }
 
-void Box2DWeldJoint::setLocalAnchorB(const QPointF &localAnchorB)
+void Box2DWeldJoint::setLocalAnchorB(const QVector2D &localAnchorB)
 {
     m_defaultLocalAnchorB = false;
 

--- a/box2dweldjoint.h
+++ b/box2dweldjoint.h
@@ -36,8 +36,8 @@ class Box2DWeldJoint : public Box2DJoint
     Q_PROPERTY(float referenceAngle READ referenceAngle WRITE setReferenceAngle NOTIFY referenceAngleChanged)
     Q_PROPERTY(float frequencyHz READ frequencyHz WRITE setFrequencyHz NOTIFY frequencyHzChanged)
     Q_PROPERTY(float dampingRatio READ dampingRatio WRITE setDampingRatio NOTIFY dampingRatioChanged)
-    Q_PROPERTY(QPointF localAnchorA READ localAnchorA WRITE setLocalAnchorA NOTIFY localAnchorAChanged)
-    Q_PROPERTY(QPointF localAnchorB READ localAnchorB WRITE setLocalAnchorB NOTIFY localAnchorBChanged)
+    Q_PROPERTY(QVector2D localAnchorA READ localAnchorA WRITE setLocalAnchorA NOTIFY localAnchorAChanged)
+    Q_PROPERTY(QVector2D localAnchorB READ localAnchorB WRITE setLocalAnchorB NOTIFY localAnchorBChanged)
 
 public:
     explicit Box2DWeldJoint(QObject *parent = 0);
@@ -51,11 +51,11 @@ public:
     float dampingRatio() const;
     void setDampingRatio(float dampingRatio);
 
-    QPointF localAnchorA() const;
-    void setLocalAnchorA(const QPointF &localAnchorA);
+    QVector2D localAnchorA() const;
+    void setLocalAnchorA(const QVector2D &localAnchorA);
 
-    QPointF localAnchorB() const;
-    void setLocalAnchorB(const QPointF &localAnchorB);
+    QVector2D localAnchorB() const;
+    void setLocalAnchorB(const QVector2D &localAnchorB);
 
     b2WeldJoint *weldJoint() const;
 
@@ -70,8 +70,8 @@ protected:
     b2Joint *createJoint();
 
 private:
-    QPointF m_localAnchorA;
-    QPointF m_localAnchorB;
+    QVector2D m_localAnchorA;
+    QVector2D m_localAnchorB;
     float m_referenceAngle;
     float m_frequencyHz;
     float m_dampingRatio;
@@ -81,12 +81,12 @@ private:
     bool m_defaultReferenceAngle;
 };
 
-inline QPointF Box2DWeldJoint::localAnchorA() const
+inline QVector2D Box2DWeldJoint::localAnchorA() const
 {
     return m_localAnchorA;
 }
 
-inline QPointF Box2DWeldJoint::localAnchorB() const
+inline QVector2D Box2DWeldJoint::localAnchorB() const
 {
     return m_localAnchorB;
 }

--- a/box2dwheeljoint.cpp
+++ b/box2dwheeljoint.cpp
@@ -42,7 +42,7 @@ Box2DWheelJoint::Box2DWheelJoint(QObject *parent)
 {
 }
 
-void Box2DWheelJoint::setLocalAnchorA(const QPointF &localAnchorA)
+void Box2DWheelJoint::setLocalAnchorA(const QVector2D &localAnchorA)
 {
     m_defaultLocalAnchorA = false;
 
@@ -53,7 +53,7 @@ void Box2DWheelJoint::setLocalAnchorA(const QPointF &localAnchorA)
     emit localAnchorAChanged();
 }
 
-void Box2DWheelJoint::setLocalAnchorB(const QPointF &localAnchorB)
+void Box2DWheelJoint::setLocalAnchorB(const QVector2D &localAnchorB)
 {
     m_defaultLocalAnchorB = false;
 
@@ -64,7 +64,7 @@ void Box2DWheelJoint::setLocalAnchorB(const QPointF &localAnchorB)
     emit localAnchorBChanged();
 }
 
-void Box2DWheelJoint::setLocalAxisA(const QPointF &localAxisA)
+void Box2DWheelJoint::setLocalAxisA(const QVector2D &localAxisA)
 {
     m_defaultLocalAxisA = false;
 
@@ -177,11 +177,11 @@ float Box2DWheelJoint::getJointSpeed() const
     return 0;
 }
 
-QPointF Box2DWheelJoint::getReactionForce(float32 inv_dt) const
+QVector2D Box2DWheelJoint::getReactionForce(float32 inv_dt) const
 {
     if (wheelJoint())
         return invertY(wheelJoint()->GetReactionForce(inv_dt));
-    return QPointF();
+    return QVector2D();
 }
 
 float Box2DWheelJoint::getReactionTorque(float32 inv_dt) const

--- a/box2dwheeljoint.h
+++ b/box2dwheeljoint.h
@@ -34,9 +34,9 @@ class Box2DWheelJoint : public Box2DJoint
 {
     Q_OBJECT
 
-    Q_PROPERTY(QPointF localAnchorA READ localAnchorA WRITE setLocalAnchorA NOTIFY localAnchorAChanged)
-    Q_PROPERTY(QPointF localAnchorB READ localAnchorB WRITE setLocalAnchorB NOTIFY localAnchorBChanged)
-    Q_PROPERTY(QPointF localAxisA READ localAxisA WRITE setLocalAxisA NOTIFY localAxisAChanged)
+    Q_PROPERTY(QVector2D localAnchorA READ localAnchorA WRITE setLocalAnchorA NOTIFY localAnchorAChanged)
+    Q_PROPERTY(QVector2D localAnchorB READ localAnchorB WRITE setLocalAnchorB NOTIFY localAnchorBChanged)
+    Q_PROPERTY(QVector2D localAxisA READ localAxisA WRITE setLocalAxisA NOTIFY localAxisAChanged)
     Q_PROPERTY(float dampingRatio READ dampingRatio WRITE setDampingRatio NOTIFY dampingRatioChanged)
     Q_PROPERTY(float frequencyHz READ frequencyHz WRITE setFrequencyHz NOTIFY frequencyHzChanged)
     Q_PROPERTY(float maxMotorTorque READ maxMotorTorque WRITE setMaxMotorTorque NOTIFY maxMotorTorqueChanged)
@@ -46,14 +46,14 @@ class Box2DWheelJoint : public Box2DJoint
 public:
     explicit Box2DWheelJoint(QObject *parent = 0);
 
-    QPointF localAnchorA() const;
-    void setLocalAnchorA(const QPointF &localAnchorA);
+    QVector2D localAnchorA() const;
+    void setLocalAnchorA(const QVector2D &localAnchorA);
 
-    QPointF localAnchorB() const;
-    void setLocalAnchorB(const QPointF &localAnchorB);
+    QVector2D localAnchorB() const;
+    void setLocalAnchorB(const QVector2D &localAnchorB);
 
-    QPointF localAxisA() const;
-    void setLocalAxisA(const QPointF &localAxisA);
+    QVector2D localAxisA() const;
+    void setLocalAxisA(const QVector2D &localAxisA);
 
     bool enableMotor() const;
     void setEnableMotor(bool enableMotor);
@@ -72,7 +72,7 @@ public:
 
     b2WheelJoint *wheelJoint() const;
 
-    Q_INVOKABLE QPointF getReactionForce(float32 inv_dt) const;
+    Q_INVOKABLE QVector2D getReactionForce(float32 inv_dt) const;
     Q_INVOKABLE float getReactionTorque(float32 inv_dt) const;
     Q_INVOKABLE float getJointTranslation() const;
     Q_INVOKABLE float getJointSpeed() const;
@@ -91,9 +91,9 @@ protected:
     b2Joint *createJoint();
 
 private:
-    QPointF m_localAnchorA;
-    QPointF m_localAnchorB;
-    QPointF m_localAxisA;
+    QVector2D m_localAnchorA;
+    QVector2D m_localAnchorB;
+    QVector2D m_localAxisA;
     bool m_enableMotor;
     float m_maxMotorTorque;
     float m_motorSpeed;
@@ -105,17 +105,17 @@ private:
     bool m_defaultLocalAxisA;
 };
 
-inline QPointF Box2DWheelJoint::localAnchorA() const
+inline QVector2D Box2DWheelJoint::localAnchorA() const
 {
     return m_localAnchorA;
 }
 
-inline QPointF Box2DWheelJoint::localAnchorB() const
+inline QVector2D Box2DWheelJoint::localAnchorB() const
 {
     return m_localAnchorB;
 }
 
-inline QPointF Box2DWheelJoint::localAxisA() const
+inline QVector2D Box2DWheelJoint::localAxisA() const
 {
     return m_localAxisA;
 }

--- a/box2dworld.cpp
+++ b/box2dworld.cpp
@@ -191,12 +191,12 @@ void Box2DWorld::setPositionIterations(int iterations)
     }
 }
 
-QPointF Box2DWorld::gravity() const
+QVector2D Box2DWorld::gravity() const
 {
     return invertY(mWorld.GetGravity());
 }
 
-void Box2DWorld::setGravity(const QPointF &gravity)
+void Box2DWorld::setGravity(const QVector2D &gravity)
 {
     const b2Vec2 invertedGravity = invertY(gravity);
     if (mWorld.GetGravity() == invertedGravity)
@@ -332,8 +332,8 @@ void Box2DWorld::step()
 }
 
 void Box2DWorld::rayCast(Box2DRayCast *rayCast,
-                         const QPointF &point1,
-                         const QPointF &point2)
+                         const QVector2D &point1,
+                         const QVector2D &point2)
 {
     mWorld.RayCast(rayCast, toMeters(point1), toMeters(point2));
 }

--- a/box2dworld.h
+++ b/box2dworld.h
@@ -116,7 +116,7 @@ class Box2DWorld : public QObject, public QQmlParserStatus, b2DestructionListene
     Q_PROPERTY(float timeStep READ timeStep WRITE setTimeStep NOTIFY timeStepChanged)
     Q_PROPERTY(int velocityIterations READ velocityIterations WRITE setVelocityIterations NOTIFY velocityIterationsChanged)
     Q_PROPERTY(int positionIterations READ positionIterations WRITE setPositionIterations NOTIFY positionIterationsChanged)
-    Q_PROPERTY(QPointF gravity READ gravity WRITE setGravity NOTIFY gravityChanged)
+    Q_PROPERTY(QVector2D gravity READ gravity WRITE setGravity NOTIFY gravityChanged)
     Q_PROPERTY(bool autoClearForces READ autoClearForces WRITE setAutoClearForces NOTIFY autoClearForcesChanged)
     Q_PROPERTY(Box2DProfile *profile READ profile NOTIFY stepped)
     Q_PROPERTY(float pixelsPerMeter READ pixelsPerMeter WRITE setPixelsPerMeter NOTIFY pixelsPerMeterChanged)
@@ -140,8 +140,8 @@ public:
     int positionIterations() const;
     void setPositionIterations(int iterations);
 
-    QPointF gravity() const;
-    void setGravity(const QPointF &gravity);
+    QVector2D gravity() const;
+    void setGravity(const QVector2D &gravity);
 
     bool autoClearForces() const;
     void setAutoClearForces(bool autoClearForces);
@@ -161,8 +161,8 @@ public:
     float toPixels(float length) const;
     float toMeters(float length) const;
 
-    QPointF toPixels(const b2Vec2 &vec) const;
-    b2Vec2 toMeters(const QPointF &point) const;
+    QVector2D toPixels(const b2Vec2 &vec) const;
+    b2Vec2 toMeters(const QVector2D &point) const;
 
     bool isSynchronizing() const;
 
@@ -178,8 +178,8 @@ public:
     Q_INVOKABLE void step();
     Q_INVOKABLE void clearForces();
     Q_INVOKABLE void rayCast(Box2DRayCast *rayCast,
-                             const QPointF &point1,
-                             const QPointF &point2);
+                             const QVector2D &point1,
+                             const QVector2D &point2);
 
 signals:
     void preSolve(Box2DContact * contact);
@@ -351,16 +351,16 @@ inline float Box2DWorld::toMeters(float length) const
 /**
  * Converts positions and sizes from Box2D to QML coordinates.
  */
-inline QPointF Box2DWorld::toPixels(const b2Vec2 &vec) const
+inline QVector2D Box2DWorld::toPixels(const b2Vec2 &vec) const
 {
-    return QPointF(vec.x * pixelsPerMeter(),
+    return QVector2D(vec.x * pixelsPerMeter(),
                    vec.y * pixelsPerMeterY());
 }
 
 /**
  * Converts positions and sizes from QML to Box2D coordinates.
  */
-inline b2Vec2 Box2DWorld::toMeters(const QPointF &point) const
+inline b2Vec2 Box2DWorld::toMeters(const QVector2D &point) const
 {
     return b2Vec2(point.x() * metersPerPixel(),
                   point.y() * metersPerPixelY());
@@ -385,15 +385,15 @@ inline void Box2DWorld::clearForces()
 /**
  * Inverts the y-axis as required for forces and velocities.
  */
-inline QPointF invertY(const b2Vec2 &vec)
+inline QVector2D invertY(const b2Vec2 &vec)
 {
-    return QPointF(vec.x, -vec.y);
+    return QVector2D(vec.x, -vec.y);
 }
 
 /**
  * Inverts the y-axis as required for forces and velocities.
  */
-inline b2Vec2 invertY(const QPointF &vec)
+inline b2Vec2 invertY(const QVector2D &vec)
 {
     return b2Vec2(vec.x(), -vec.y());
 }


### PR DESCRIPTION
Working with the Qt.vector2d type in QML brings the benefits of vector operation functions such as dot(), times(), plus(), normalized(), etc. These are not available to the Qt.point type currently used by qml-box2d. The only way to access the operations is currently to convert a Qt.point to Qt.vector2d, which creates a lot of code overhead in simlpe scripts.

Note that this change breaks the API for all code that explicitly uses Qt.point to set or hold values. Code that uses the notation "linearVelocity.x: 123" and "linearVelocity.y: 456" still works as expected.