### PR TITLE
raycast example: fix "'beginContact' is not a function" error.

### DIFF
--- a/examples/raycast/Wall.qml
+++ b/examples/raycast/Wall.qml
@@ -12,7 +12,7 @@ PhysicsItem {
         height: wall.height
         friction: 1
         density: 1
-        onBeginContact: parent.beginContact(other)
+        onBeginContact: wall.beginContact(other)
     }
 
     Image {


### PR DESCRIPTION
The error was:

Wall.qml:15: TypeError: Property 'beginContact' of object
QQuickItem(0x6910e78) is not a function

It could be reproduced by shortening the blue ray and waiting.