### PR TITLE
Add examples.pri to enable quick location of example QML files.

### DIFF
--- a/box2d.pro
+++ b/box2d.pro
@@ -11,6 +11,7 @@ contains(QT_CONFIG, reduce_exports): CONFIG += hide_symbols
 
 INCLUDEPATH += .
 include(Box2D/box2d.pri)
+include(examples/examples.pri)
 
 importPath = $$[QT_INSTALL_QML]/$$replace(TARGETPATH, \\., /).$$API_VER
 target.path = $${importPath}

--- a/examples/examples.pri
+++ b/examples/examples.pri
@@ -1,0 +1,25 @@
+OTHER_FILES += \
+    $$PWD/accelerometer/*.qml \
+    $$PWD/boxes/*.qml \
+    $$PWD/cannon/*.qml \
+    $$PWD/contacts/*.qml \
+    $$PWD/demolition/*.qml \
+    $$PWD/distance/*.qml \
+    $$PWD/filtering/*.qml \
+    $$PWD/fixtures/*.qml \
+    $$PWD/friction/*.qml \
+    $$PWD/gear/*.qml \
+    $$PWD/impulse/*.qml \
+    $$PWD/monera/*.qml \
+    $$PWD/motorjoint/*.qml \
+    $$PWD/mouse/*.qml \
+    $$PWD/movingBox/*.qml \
+    $$PWD/polygons/*.qml \
+    $$PWD/prismatic/*.qml \
+    $$PWD/pulley/*.qml \
+    $$PWD/raycast/*.qml \
+    $$PWD/revolute/*.qml \
+    $$PWD/rope/*.qml \
+    $$PWD/shared/*.qml \
+    $$PWD/weld/*.qml \
+    $$PWD/wheel/*.qml


### PR DESCRIPTION
This makes all QML files for the examples show up in Qt Creator's
locator.