### PR TITLE
Fix workaround with setting transformOrigin

### DIFF
--- a/box2dbody.cpp
+++ b/box2dbody.cpp
@@ -33,6 +33,7 @@
 
 #include "box2dfixture.h"
 #include "box2dworld.h"
+#include <qmath.h>
 
 static bool sync(float &value, float newValue)
 {
@@ -243,6 +244,18 @@ Box2DFixture *Box2DBody::at_fixture(QQmlListProperty<Box2DFixture> *list, int in
     return body->mFixtures.at(index);
 }
 
+QPointF Box2DBody::originOffset() const
+{
+    Q_ASSERT(mTarget);
+
+    QPointF origin = -mTarget->transformOriginPoint();
+    qreal c = qCos(-mBodyDef.angle);
+    qreal s = qSin(-mBodyDef.angle);
+
+    return QPointF(origin.x() * c - origin.y() * s - origin.x(),
+                   origin.x() * s + origin.y() * c - origin.y());
+}
+
 void Box2DBody::addFixture(Box2DFixture *fixture)
 {
     mFixtures.append(fixture);
@@ -264,9 +277,13 @@ void Box2DBody::createBody()
     }
 
     if (mTarget) {
-        mBodyDef.position = mWorld->toMeters(mTarget->position());
         mBodyDef.angle = toRadians(mTarget->rotation());
+        mBodyDef.position = mWorld->toMeters(
+                    mTarget->transformOrigin() == QQuickItem::TopLeft ?
+                        mTarget->position() :
+                        mTarget->position() + originOffset());
     }
+
     mBody = mWorld->world().CreateBody(&mBodyDef);
     mCreatePending = false;
     mTransformDirty = false;
@@ -282,15 +299,20 @@ void Box2DBody::synchronize()
 {
     Q_ASSERT(mBody);
 
-    if (sync(mBodyDef.position, mBody->GetPosition())) {
-        if (mTarget)
-            mTarget->setPosition(mWorld->toPixels(mBodyDef.position));
-        emit positionChanged();
-    }
-
     if (sync(mBodyDef.angle, mBody->GetAngle()))
         if (mTarget)
             mTarget->setRotation(toDegrees(mBodyDef.angle));
+
+    if (sync(mBodyDef.position, mBody->GetPosition())) {
+        if (mTarget) {
+            mTarget->setPosition(
+                        mTarget->transformOrigin() == QQuickItem::TopLeft ?
+                            mWorld->toPixels(mBodyDef.position) :
+                            mWorld->toPixels(mBodyDef.position) - originOffset());
+
+        }
+        emit positionChanged();
+    }
 }
 
 void Box2DBody::classBegin()
@@ -351,8 +373,12 @@ void Box2DBody::updateTransform()
     Q_ASSERT(mBody);
     Q_ASSERT(mTransformDirty);
 
-    mBodyDef.position = mWorld->toMeters(mTarget->position());
     mBodyDef.angle = toRadians(mTarget->rotation());
+    mBodyDef.position = mWorld->toMeters(
+                mTarget->transformOrigin() == QQuickItem::TopLeft ?
+                    mTarget->position() :
+                    mTarget->position() + originOffset());
+
     mBody->SetTransform(mBodyDef.position, mBodyDef.angle);
     mTransformDirty = false;
 }

--- a/box2dbody.h
+++ b/box2dbody.h
@@ -178,6 +178,7 @@ private:
                                Box2DFixture *fixture);
     static int count_fixture(QQmlListProperty<Box2DFixture> *list);
     static Box2DFixture *at_fixture(QQmlListProperty<Box2DFixture> *list, int index);
+    QPointF originOffset() const;
 };
 
 inline QQuickItem *Box2DBody::target() const


### PR DESCRIPTION
Small patch to avoid `transformOrigin:Item.TopLeft` workaround in QML code. So now, if target item uses another value of transformOrigin then `Item.TopLeft` this patch corrects coordinates according to origin point offset.