### PR TITLE
Make Body.target optional

### DIFF
--- a/box2dbody.cpp
+++ b/box2dbody.cpp
@@ -263,6 +263,9 @@ void Box2DBody::createBody()
         return;
     }
 
+    if (!mTarget)
+        mTarget = qobject_cast<QQuickItem *>(parent());
+
     if (mTarget) {
         mBodyDef.position = mWorld->toMeters(mTarget->position());
         mBodyDef.angle = toRadians(mTarget->rotation());


### PR DESCRIPTION
This patch allows avoid setting `target` when a `Body` is direct child of probable target (i.e. QQuickItem descendant). It still possible to override that by setting `target` manually.