### PR TITLE
Allow to avoid setting Body.world if there is only one World

### DIFF
--- a/box2dbody.cpp
+++ b/box2dbody.cpp
@@ -63,6 +63,7 @@ Box2DBody::Box2DBody(QObject *parent) :
     mCreatePending(false)
 {
     mBodyDef.userData = this;
+    setWorld(Box2DWorld::defaultWorld());
 }
 
 Box2DBody::~Box2DBody()

--- a/box2ddebugdraw.cpp
+++ b/box2ddebugdraw.cpp
@@ -254,6 +254,7 @@ Box2DDebugDraw::Box2DDebugDraw(QQuickItem *parent) :
     mFlags(Everything)
 {
     setFlag(QQuickItem::ItemHasContents, true);
+    setWorld(Box2DWorld::defaultWorld());
 }
 
 void Box2DDebugDraw::setAxisScale(qreal axisScale)

--- a/box2dworld.cpp
+++ b/box2dworld.cpp
@@ -120,6 +120,8 @@ void ContactListener::PostSolve(b2Contact *contact, const b2ContactImpulse *impu
     emit mWorld->postSolve(&mContact);
 }
 
+static Box2DWorld * mDefaultWorld;
+
 Box2DWorld::Box2DWorld(QObject *parent) :
     QObject(parent),
     mWorld(b2Vec2(0.0f, -10.0f)),
@@ -137,6 +139,8 @@ Box2DWorld::Box2DWorld(QObject *parent) :
 
 {
     mWorld.SetDestructionListener(this);
+    if (!mDefaultWorld)
+        mDefaultWorld = this;
 }
 
 Box2DWorld::~Box2DWorld()
@@ -149,6 +153,8 @@ Box2DWorld::~Box2DWorld()
     for (b2Joint *joint = mWorld.GetJointList(); joint; joint = joint->GetNext())
         toBox2DJoint(joint)->nullifyJoint();
     enableContactListener(false);
+    if (mDefaultWorld == this)
+        mDefaultWorld = 0;
 }
 
 void Box2DWorld::setTimeStep(float timeStep)
@@ -336,4 +342,9 @@ void Box2DWorld::rayCast(Box2DRayCast *rayCast,
                          const QPointF &point2)
 {
     mWorld.RayCast(rayCast, toMeters(point1), toMeters(point2));
+}
+
+Box2DWorld *Box2DWorld::defaultWorld()
+{
+    return mDefaultWorld;
 }

--- a/box2dworld.h
+++ b/box2dworld.h
@@ -180,6 +180,7 @@ public:
     Q_INVOKABLE void rayCast(Box2DRayCast *rayCast,
                              const QPointF &point1,
                              const QPointF &point2);
+    static Box2DWorld * defaultWorld();
 
 signals:
     void preSolve(Box2DContact * contact);


### PR DESCRIPTION
I guess in most of projects there is only one `World` so setting `Body.world` looks superfluous. Therefore, now the first created world assigned to default one and all created bodies attached to it (certainly, if `world` wasn't specified). It still possible to override it be setting `world` manually.