### PR TITLE
Update examples, remove unnecessary transformOrigin

### DIFF
--- a/examples/cannon/main.qml
+++ b/examples/cannon/main.qml
@@ -20,7 +20,6 @@ Rectangle {
             x: 400
             color: "orange"
             radius: 10
-            transformOrigin: Item.TopLeft
 
             property Body body: circleBody
 
@@ -56,7 +55,6 @@ Rectangle {
             radius: 5
             color: "black"
             smooth: true
-            transformOrigin: Item.TopLeft
 
             property Body body: circleBody
 
@@ -107,8 +105,8 @@ Rectangle {
         }
         for (i = 0; i < 4; i ++) {
             newDomino = dominoComponent.createObject(root);
-            newDomino.x = 555 + 50 * i;
-            newDomino.y = 500;
+            newDomino.x = 525 + 50 * i;
+            newDomino.y = 480;
             newDomino.rotation = 90;
         }
         for (i = 0; i < 4; i ++) {
@@ -118,8 +116,8 @@ Rectangle {
         }
         for (i = 0; i < 3; i ++) {
             newDomino = dominoComponent.createObject(root);
-            newDomino.x = 580 + 50 * i;
-            newDomino.y = 440;
+            newDomino.x = 550 + 50 * i;
+            newDomino.y = 420;
             newDomino.rotation = 90;
         }
     }

--- a/examples/demolition/WoodenBox.qml
+++ b/examples/demolition/WoodenBox.qml
@@ -7,7 +7,6 @@ Item {
 
     width: 100
     height: 100
-    transformOrigin: Item.TopLeft
 
     BoxBody {
         id: body

--- a/examples/demolition/demolition.qml
+++ b/examples/demolition/demolition.qml
@@ -22,7 +22,6 @@ Image {
         id: wheelComponent
         Image {
             id: wheel
-            transformOrigin: Item.TopLeft
 
             smooth: true
             source: "images/wheel.png"

--- a/examples/distance/Ball.qml
+++ b/examples/distance/Ball.qml
@@ -4,7 +4,6 @@ import Box2D 2.0
 Rectangle {
     id: ball
 
-    transformOrigin: Item.TopLeft
     radius: 180
 
     gradient: Gradient {

--- a/examples/distance/Square.qml
+++ b/examples/distance/Square.qml
@@ -7,8 +7,6 @@ Rectangle {
 
     color: "green"
 
-    transformOrigin: Item.TopLeft
-
     property Body body: BoxBody {
         width: square.width
         height: square.height

--- a/examples/fixtures/main.qml
+++ b/examples/fixtures/main.qml
@@ -13,7 +13,6 @@ Rectangle {
         Rectangle {
             id: ball
 
-            transformOrigin: Item.TopLeft
             width: 20
             height: 20
             radius: 10

--- a/examples/friction/main.qml
+++ b/examples/friction/main.qml
@@ -30,6 +30,7 @@ Rectangle {
             border.color: "blue"
             color: "#EFEFEF"
             smooth: true
+            antialiasing: true
 
             world: physicsWorld
             bodyType: Body.Dynamic

--- a/examples/gear/main.qml
+++ b/examples/gear/main.qml
@@ -246,6 +246,7 @@ Rectangle {
         Rectangle {
             anchors.fill: parent
             color: "brown"
+            antialiasing: true
         }
     }
 
@@ -272,6 +273,7 @@ Rectangle {
         Rectangle {
             anchors.fill: parent
             color: "brown"
+            antialiasing: true
         }
     }
 

--- a/examples/mouse/main.qml
+++ b/examples/mouse/main.qml
@@ -107,7 +107,6 @@ Rectangle {
             color: randomColor()
             border.color: randomColor()
             smooth: true
-            transformOrigin: Item.TopLeft
 
             Body {
                 id: rectangleBody

--- a/examples/prismatic/Square.qml
+++ b/examples/prismatic/Square.qml
@@ -7,7 +7,6 @@ Rectangle {
 
     color: "green"
     radius: 6
-    transformOrigin: Item.TopLeft
 
     property Body body: BoxBody {
         target: item

--- a/examples/prismatic/prismatic.qml
+++ b/examples/prismatic/prismatic.qml
@@ -18,7 +18,7 @@ Item {
             height: 80
             smooth: true
             color: "black"
-            transformOrigin: Item.TopLeft
+
             CircleBody {
                 target: rectangle
                 world: physicsWorld

--- a/examples/raycast/main.qml
+++ b/examples/raycast/main.qml
@@ -14,7 +14,6 @@ Rectangle {
             width: 20
             height: 20
             bodyType: Body.Dynamic
-            property bool burn: false
 
             fixtures: Circle {
                 property bool isBall: true
@@ -31,31 +30,6 @@ Rectangle {
                 width: parent.width
                 height: parent.height
                 radius: 10
-                SequentialAnimation {
-                    running: ball.burn
-                    PropertyAnimation {
-                        target: ballShape
-                        property: "color"
-                        to: "red"
-                        duration: 50
-                    }
-                    PropertyAnimation {
-                        target: ballShape
-                        property: "color"
-                        to: "yellow"
-                        duration: 50
-                    }
-                    PropertyAnimation {
-                        target: ballShape
-                        property: "opacity"
-                        to: 0
-                        duration: 50
-                    }
-                    onRunningChanged: {
-                        if (!running)
-                            ball.destroy();
-                    }
-                }
             }
         }
     }
@@ -63,9 +37,10 @@ Rectangle {
     World {
         id: physicsWorld
 
-        onStepped: physicsWorld.rayCast(sensorRay,
-                                        sensorRay.point1,
-                                        sensorRay.point2)
+        onStepped:
+            physicsWorld.rayCast(sensorRay,
+                                 sensorRay.point1,
+                                 sensorRay.point2)
     }
 
     Item {
@@ -151,31 +126,6 @@ Rectangle {
             height: 1
             color: "aqua"
             opacity: 1
-        }
-
-        RayCast {
-            id: laserRay
-            onFixtureReported: fixture.getBody().target.burn = true
-            function cast() {
-                physicsWorld.rayCast(this, Qt.point(40, 300), Qt.point(700, 300))
-            }
-        }
-
-        Rectangle {
-            id: laser
-            x: 40
-            y: 300
-            width: 700
-            height: 1
-            color: "red"
-            opacity: 0
-            PropertyAnimation {
-                id: rayImpulseFadeoutAnimation
-                target: laser
-                property: "opacity"
-                to: 0
-                duration: 100
-            }
         }
 
         PhysicsItem {
@@ -294,18 +244,6 @@ Rectangle {
             var newBall = ballComponent.createObject(physicsRoot);
             newBall.x = 100 + (Math.random() * 600);
             newBall.y = 50;
-        }
-    }
-
-    Timer {
-        id: impulseTimer
-        interval: 600
-        running: true
-        repeat: true
-        onTriggered: {
-            laserRay.cast();
-            laser.opacity = 1;
-            rayImpulseFadeoutAnimation.running = true;
         }
     }
 }

--- a/examples/rope/main.qml
+++ b/examples/rope/main.qml
@@ -154,7 +154,7 @@ Rectangle {
         id: debugDraw
         world: physicsWorld
         opacity: 1
-//        visible: false
+        visible: false
     }
 
     Timer {

--- a/examples/shared/ImageBoxBody.qml
+++ b/examples/shared/ImageBoxBody.qml
@@ -4,8 +4,6 @@ import Box2D 2.0
 Image {
     id: image
 
-    transformOrigin: Item.TopLeft
-
     property alias body: boxBody
     property alias fixture: box
 

--- a/examples/shared/PhysicsItem.qml
+++ b/examples/shared/PhysicsItem.qml
@@ -4,8 +4,6 @@ import Box2D 2.0
 Item {
     id: item
 
-    transformOrigin: Item.TopLeft
-
     property alias body: itemBody
 
     // Body properties

--- a/examples/shared/RectangleBoxBody.qml
+++ b/examples/shared/RectangleBoxBody.qml
@@ -4,8 +4,6 @@ import Box2D 2.0
 Rectangle {
     id: rectangle
 
-    transformOrigin: Item.TopLeft
-
     property alias body: boxBody
     property alias fixture: box
 


### PR DESCRIPTION
Since #91 `transformOrigin` is unnecessary to syncronize `Body` and its target so I removed it from all the examples. Also part of `raycast` example was broken, maybe due to one of last patches so I removed it. I'll fix it later as soon as I have time