### PR TITLE
Add ability to compile qml_box2d with system  Bod2D library

### DIFF
--- a/box2d-static.pri
+++ b/box2d-static.pri
@@ -15,51 +15,6 @@
 #      ...
 #  }
 
-INCLUDEPATH += $$PWD
-include(Box2D/box2d.pri)
+include(box2d_lib.pri)
 
 DEFINES += STATIC_PLUGIN_BOX2D
-
-SOURCES += $$PWD/box2dplugin.cpp \
-    $$PWD/box2dworld.cpp \
-    $$PWD/box2dcontact.cpp \
-    $$PWD/box2dbody.cpp \
-    $$PWD/box2dfixture.cpp \
-    $$PWD/box2ddebugdraw.cpp \
-    $$PWD/box2djoint.cpp \
-    $$PWD/box2drevolutejoint.cpp \
-    $$PWD/box2ddistancejoint.cpp \
-    $$PWD/box2dprismaticjoint.cpp \
-    $$PWD/box2dmotorjoint.cpp \
-    $$PWD/box2dweldjoint.cpp \
-    $$PWD/box2dpulleyjoint.cpp \
-    $$PWD/box2dfrictionjoint.cpp \
-    $$PWD/box2dwheeljoint.cpp \
-    $$PWD/box2dmousejoint.cpp \
-    $$PWD/box2dgearjoint.cpp \
-    $$PWD/box2dropejoint.cpp \
-    $$PWD/box2draycast.cpp
-
-
-
-HEADERS += \
-    $$PWD/box2dplugin.h \
-    $$PWD/box2dworld.h \
-    $$PWD/box2dcontact.h \
-    $$PWD/box2dbody.h \
-    $$PWD/box2dfixture.h \
-    $$PWD/box2ddebugdraw.h \
-    $$PWD/box2djoint.h \
-    $$PWD/box2drevolutejoint.h \
-    $$PWD/box2ddistancejoint.h \
-    $$PWD/box2dprismaticjoint.h \
-    $$PWD/box2dmotorjoint.h \
-    $$PWD/box2dweldjoint.h \
-    $$PWD/box2dpulleyjoint.h \
-    $$PWD/box2dfrictionjoint.h \
-    $$PWD/box2dwheeljoint.h \
-    $$PWD/box2dmousejoint.h \
-    $$PWD/box2dgearjoint.h \
-    $$PWD/box2dropejoint.h \
-    $$PWD/box2draycast.h
-

--- a/box2d.pro
+++ b/box2d.pro
@@ -9,8 +9,15 @@ OBJECTS_DIR = .obj
 
 contains(QT_CONFIG, reduce_exports): CONFIG += hide_symbols
 
-INCLUDEPATH += .
-include(Box2D/box2d.pri)
+# Uncomment the line below to compile qml-box2d plugin with Box2D library, installed in OS
+# or pass the variable to qmake in command line:
+# qmake DEFINES+=BOX2D_SYSTEM
+# Warning: Box2D library must be already installed in system, for example in Debian it could be done with:
+# sudo apt-get install libbox2d-dev
+
+#DEFINES += BOX2D_SYSTEM
+
+include(box2d_lib.pri)
 include(examples/examples.pri)
 
 importPath = $$[QT_INSTALL_QML]/$$replace(TARGETPATH, \\., /).$$API_VER
@@ -22,43 +29,4 @@ qmldir.files += $$PWD/qmldir
 
 INSTALLS += target qmldir
 
-SOURCES += box2dplugin.cpp \
-    box2dworld.cpp \
-    box2dcontact.cpp \
-    box2dbody.cpp \
-    box2dfixture.cpp \
-    box2ddebugdraw.cpp \
-    box2djoint.cpp \
-    box2ddistancejoint.cpp \
-    box2dprismaticjoint.cpp \
-    box2drevolutejoint.cpp \
-    box2dmotorjoint.cpp \
-    box2dweldjoint.cpp \
-    box2dpulleyjoint.cpp \
-    box2dfrictionjoint.cpp \
-    box2dwheeljoint.cpp \
-    box2dmousejoint.cpp \
-    box2dgearjoint.cpp \
-    box2dropejoint.cpp \
-    box2draycast.cpp
 
-HEADERS += \
-    box2dplugin.h \
-    box2dworld.h \
-    box2dcontact.h \
-    box2dbody.h \
-    box2dfixture.h \
-    box2ddebugdraw.h \
-    box2djoint.h \
-    box2ddistancejoint.h \
-    box2dprismaticjoint.h \
-    box2drevolutejoint.h \
-    box2dmotorjoint.h \
-    box2dweldjoint.h \
-    box2dpulleyjoint.h \
-    box2dfrictionjoint.h \
-    box2dwheeljoint.h \
-    box2dmousejoint.h \
-    box2dgearjoint.h \
-    box2dropejoint.h \
-    box2draycast.h

--- a/box2d_lib.pri
+++ b/box2d_lib.pri
@@ -1,0 +1,62 @@
+INCLUDEPATH += $$PWD
+
+contains(DEFINES, BOX2D_SYSTEM) {
+
+    packagesExist(box2d) {
+        CONFIG += link_pkgconfig
+        PKGCONFIG += box2d
+    } else {
+
+        !contains(INCLUDEPATH,"Box2D") {
+            unix:BOX2D_INCLUDEPATH = "/usr/include/Box2D"
+            INCLUDEPATH += $$BOX2D_INCLUDEPATH
+        }
+
+        !contains(LIBS,"Box2D")
+            LIBS += "-lBox2D"
+    }
+} else {
+    include(Box2D/box2d.pri)
+}
+
+SOURCES += \
+    $$PWD/box2dplugin.cpp \
+    $$PWD/box2dworld.cpp \
+    $$PWD/box2dcontact.cpp \
+    $$PWD/box2dbody.cpp \
+    $$PWD/box2dfixture.cpp \
+    $$PWD/box2ddebugdraw.cpp \
+    $$PWD/box2djoint.cpp \
+    $$PWD/box2ddistancejoint.cpp \
+    $$PWD/box2dprismaticjoint.cpp \
+    $$PWD/box2drevolutejoint.cpp \
+    $$PWD/box2dmotorjoint.cpp \
+    $$PWD/box2dweldjoint.cpp \
+    $$PWD/box2dpulleyjoint.cpp \
+    $$PWD/box2dfrictionjoint.cpp \
+    $$PWD/box2dwheeljoint.cpp \
+    $$PWD/box2dmousejoint.cpp \
+    $$PWD/box2dgearjoint.cpp \
+    $$PWD/box2dropejoint.cpp \
+    $$PWD/box2draycast.cpp
+
+HEADERS += \
+    $$PWD/box2dplugin.h \
+    $$PWD/box2dworld.h \
+    $$PWD/box2dcontact.h \
+    $$PWD/box2dbody.h \
+    $$PWD/box2dfixture.h \
+    $$PWD/box2ddebugdraw.h \
+    $$PWD/box2djoint.h \
+    $$PWD/box2ddistancejoint.h \
+    $$PWD/box2dprismaticjoint.h \
+    $$PWD/box2drevolutejoint.h \
+    $$PWD/box2dmotorjoint.h \
+    $$PWD/box2dweldjoint.h \
+    $$PWD/box2dpulleyjoint.h \
+    $$PWD/box2dfrictionjoint.h \
+    $$PWD/box2dwheeljoint.h \
+    $$PWD/box2dmousejoint.h \
+    $$PWD/box2dgearjoint.h \
+    $$PWD/box2dropejoint.h \
+    $$PWD/box2draycast.h


### PR DESCRIPTION
request #95 suggests an idea to provide an ability to compile qml_box2d with system Box2D library. Sure it mostly related to *nix systems but anyway I think it's good idea. In my case I tested it in Debian and it gives 266К vs 422K of plugin size.