### PR TITLE
System box2d and debian packaging changes

### DIFF
--- a/README
+++ b/README
@@ -14,6 +14,11 @@ INSTALLING
  make
  make install  (goes to Qt's import path, run with sudo if necessary)
 
+INSTALLING - Debian
+
+ debuild -uc -us -b
+ sudo dpkg -i ../qml-box2d_*.deb
+
 
 RUNNING THE EXAMPLE
 

--- a/box2d.pro
+++ b/box2d.pro
@@ -11,11 +11,11 @@ contains(QT_CONFIG, reduce_exports): CONFIG += hide_symbols
 
 # Uncomment the line below to compile qml-box2d plugin with Box2D library, installed in OS
 # or pass the variable to qmake in command line:
-# qmake DEFINES+=BOX2D_SYSTEM
+# qmake CONFIG+=BOX2D_SYSTEM
 # Warning: Box2D library must be already installed in system, for example in Debian it could be done with:
 # sudo apt-get install libbox2d-dev
 
-#DEFINES += BOX2D_SYSTEM
+#CONFIG += BOX2D_SYSTEM
 
 include(box2d_lib.pri)
 include(examples/examples.pri)

--- a/box2d_lib.pri
+++ b/box2d_lib.pri
@@ -1,7 +1,7 @@
 INCLUDEPATH += $$PWD
 
-contains(DEFINES, BOX2D_SYSTEM) {
-
+contains(CONFIG, BOX2D_SYSTEM) {
+    message(Building with system Box2d)
     packagesExist(box2d) {
         CONFIG += link_pkgconfig
         PKGCONFIG += box2d

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: qml-box2d
 Section: libs
 Priority: extra
 Maintainer: Ville Ranki <ville.ranki@iki.fi>
-Build-Depends: cdbs, debhelper (>= 7.0.50~), qtbase5-dev, qtdeclarative5-dev
+Build-Depends: cdbs, debhelper (>= 7.0.50~), libbox2d-dev, qtbase5-dev, qtdeclarative5-dev
 Standards-Version: 3.9.6
 
 Package: qml-box2d

--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,7 @@
 #!/usr/bin/make -f
 
+DEB_QMAKE_CONFIG_VAL=BOX2D_SYSTEM
+
 include /usr/share/cdbs/1/rules/debhelper.mk
 include /usr/share/cdbs/1/class/qmake.mk
 


### PR DESCRIPTION
- Changed option to use system box2d to use CONFIG instead of DEFINES, as this is the more common way to configure qmake projects.
- Updated debian packaging to use system box2d and depend on it.
- Updated README to match the changes.
