### PR TITLE
Fix for revolute joint angle. Avoid crash when contact listener is disabled.

### DIFF
--- a/box2drevolutejoint.cpp
+++ b/box2drevolutejoint.cpp
@@ -96,7 +96,7 @@ void Box2DRevoluteJoint::setLowerAngle(float lowerAngle)
     m_lowerAngle = lowerAngle;
     if (revoluteJoint())
         revoluteJoint()->SetLimits(toRadians(lowerAngle),
-                                   m_upperAngle);
+                                   toRadians(m_upperAngle));
     emit lowerAngleChanged();
 }
 
@@ -107,7 +107,7 @@ void Box2DRevoluteJoint::setUpperAngle(float upperAngle)
 
     m_upperAngle = upperAngle;
     if (revoluteJoint())
-        revoluteJoint()->SetLimits(m_lowerAngle,
+        revoluteJoint()->SetLimits(toRadians(m_lowerAngle),
                                    toRadians(upperAngle));
     emit upperAngleChanged();
 }

--- a/box2dworld.cpp
+++ b/box2dworld.cpp
@@ -329,8 +329,8 @@ void Box2DWorld::step()
                 break;
             }
         }
+        mContactListener->clearEvents();
     }
-    mContactListener->clearEvents();
 
     mProfile->mEmitSignals = timer.GetMilliseconds();
 


### PR DESCRIPTION
Hi, two small fixes:
1. for setting revolute joint limits, the values have to be in radians. 
2. if contact listener is disabled, accessing a non-valid would crash the SW.

Best regards,
Thomas