### PR TITLE
Added QQuickItem as base of fixitures

### DIFF
--- a/box2dfixture.cpp
+++ b/box2dfixture.cpp
@@ -34,8 +34,8 @@
 
 #include "Common/b2Math.h"
 
-Box2DFixture::Box2DFixture(QObject *parent) :
-    QObject(parent),
+Box2DFixture::Box2DFixture(QQuickItem *parent) :
+    QQuickItem(parent),
     mFixture(0),
     mBody(0)
 {
@@ -228,6 +228,11 @@ void Box2DBox::setRotation(qreal rotation)
     mRotation = rotation;
     recreateFixture();
     emit rotationChanged();
+}
+
+void Box2DBox::geometryChanged(const QRectF &newGeometry, const QRectF &oldGeometry)
+{
+    qWarning() <<"geometryChanged Function is not defined";
 }
 
 b2Shape *Box2DBox::createShape()

--- a/box2dfixture.h
+++ b/box2dfixture.h
@@ -30,12 +30,13 @@
 
 #include <QQuickItem>
 #include <QFlags>
+#include <QQuickItem>
 
 #include <Box2D.h>
 
 class Box2DBody;
 
-class Box2DFixture : public QObject
+class Box2DFixture : public QQuickItem
 {
     Q_OBJECT
 
@@ -51,7 +52,7 @@ class Box2DFixture : public QObject
     Q_FLAGS(CategoryFlags)
 
 public:
-    explicit Box2DFixture(QObject *parent = 0);
+    explicit Box2DFixture(QQuickItem *parent = 0);
 
     enum CategoryFlag {Category1 = 0x0001, Category2 = 0x0002, Category3 = 0x0004, Category4 = 0x0008,
                        Category5 = 0x0010, Category6 = 0x0020, Category7 = 0x0040, Category8 = 0x0080,


### PR DESCRIPTION
The idea of this change is to allow to create custom fixiture objects with embedded resources like timers, images... or whatever you want. 

Maybe, all the other classes should derive from QQuickItem instead of QObject as QQuickItem is the base item for all the qml items.

PD:
Definition of geometryChanged added, but I don't know how this worked before without definition.

