### PR TITLE
Fix the 'make install' command bug on the android.

### DIFF
--- a/box2d.pro
+++ b/box2d.pro
@@ -6,6 +6,7 @@ TARGETPATH = Box2D
 API_VER=2.0
 MOC_DIR = .moc
 OBJECTS_DIR = .obj
+CONFIG -= android_install
 
 contains(QT_CONFIG, reduce_exports): CONFIG += hide_symbols
 


### PR DESCRIPTION
It has below error when `android_install` is activated.
`mkdir: cannot create directory ‘/libs’: Permission denied`
So I disabled it using below line to make it install to the correct path. 
`CONFIG -= android_install`
