### PR TITLE
Adding Windows/MacOS CI builds

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -3,6 +3,10 @@ name: Compile
 on:
   [ push, pull_request ]
 
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
 jobs:
   build-with-qbs:
     name: Ubuntu (Qbs)
@@ -40,6 +44,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1
+      with:
+        max-size: 100M
+
     - name: Install dependencies
       run: |
         sudo apt update
@@ -62,6 +71,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Setup ccache
+      uses: hendrikmuhs/ccache-action@v1
+      with:
+        max-size: 100M
+
     - name: Install dependencies
       run: |
         sudo apt update
@@ -74,3 +88,50 @@ jobs:
     - name: Build
       run: |
         cmake --build ${{github.workspace}}/build --config Release
+
+  build-macos-cmake-qt5:
+    name: macos
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v2
+      with:
+        version: '5.15.2'
+        host: 'mac'
+        target: 'desktop'
+        dir: '${{github.workspace}}/qt/'
+        install-deps: 'true'
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_PREFIX_PATH="${{env.Qt5_Dir}}" -DQt5_DIR=${{env.Qt5_Dir}}/lib/cmake/Qt5/ -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      
+  build-windows-cmake-qt5:
+    name: windows
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v2
+      with:
+        version: '5.15.2'
+        host: 'windows'
+        target: 'desktop'
+        arch: 'win64_mingw81'
+        dir: '${{github.workspace}}/qt/'
+        install-deps: 'true'
+
+    - name: Configure CMake
+      env:
+        CMAKE_PREFIX_PATH: ${{env.Qt5_Dir}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -G "MinGW Makefiles"
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -90,7 +90,7 @@ jobs:
         cmake --build ${{github.workspace}}/build --config Release
 
   build-macos-cmake-qt5:
-    name: macos
+    name: macOS
     runs-on: macos-latest
 
     steps:
@@ -112,7 +112,7 @@ jobs:
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
       
   build-windows-cmake-qt5:
-    name: windows
+    name: Windows
     runs-on: windows-latest
 
     steps:


### PR DESCRIPTION
I played a bit with github actions.

This PR is on top of the cmake one and is opened for discussion. Please only take a look at the last commit.

For Windows/MacOS, I added build with Qt5.15. It may make sense to not have all the possible cases (Qt5.12, Qt5.15 and Qt.6.2) but maybe switch a bit (there are matrices too in github actions but I'm not familiar and didn't want to push too far).

The second file adds linter (https://github.com/cpp-linter/cpp-linter-action): 
* Formatting checks with clang-format (as for now qml-box2d does not have one, it
* clang-tidy checks: by default, it is `boost-*,bugprone-*,performance-*,readability-*,portability-*,modernize-*,clang-analyzer-*,cppcoreguidelines-*`. Some are verbose and not useful or in my taste (for example using auto when possible) but I don't want to make choices :).
