### PR TITLE
fix crash on revoluteplotangle.

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -23,6 +23,12 @@
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTORCC ON)
 
+if(Qt6_FOUND)
+  find_package(Qt6 6.2 COMPONENTS Widgets REQUIRED)
+else()
+  find_package(Qt5 5.12 COMPONENTS Widgets REQUIRED)
+endif()
+
 add_executable(box2qml-examples
     main.cpp
     example.qrc
@@ -131,6 +137,7 @@ target_link_libraries(box2qml-examples
 PRIVATE
     ${QT_MAJOR_VERSION}::Core
     ${QT_MAJOR_VERSION}::Quick
+    ${QT_MAJOR_VERSION}::Widgets
     ${QT_MAJOR_VERSION}::Qml
 PUBLIC
     qmlbox2d

--- a/examples/example.qbs
+++ b/examples/example.qbs
@@ -11,7 +11,7 @@ Project {
         name: "Example";
 
         Depends { name: "cpp"; }
-        Depends { name: "Qt"; submodules: ["core", "qml", "quick"]; }
+        Depends { name: "Qt"; submodules: ["core", "qml", "quick", "widgets"]; }
         Depends { name: "box2d_lib"; }
 
         cpp.rpaths: ["$ORIGIN"]

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -1,4 +1,4 @@
-#include <QGuiApplication>
+#include <QApplication>
 #include <QQmlApplicationEngine>
 #include <QDebug>
 #include <QtQml>
@@ -6,7 +6,7 @@
 
 int main(int argc, char *argv[])
 {
-    QGuiApplication app(argc, argv);
+    QApplication app(argc, argv);
 
     Box2DPlugin plugin;
     plugin.registerTypes("Box2D");


### PR DESCRIPTION
According to https://bugreports.qt.io/browse/QTBUG-53544, QtCharts must link to Widgets and use QApplication

Fixes: #140 