### PR TITLE
Generate .qmltypes files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,9 @@ if(Qt6_FOUND)
         QT_QML_MODULE_VERSION 2.0
         QT_QML_MODULE_URI     Box2D
     )
+    if(QT_KNOWN_POLICY_QTP0001)
+        qt_policy(SET QTP0001 OLD)
+    endif()
     qt_add_qml_module(${QML_BOX2D_LIBRARY_NAME}
       URI Box2D
       VERSION 2.0

--- a/box2dbody.h
+++ b/box2dbody.h
@@ -31,8 +31,8 @@
 #ifndef BOX2DBODY_H
 #define BOX2DBODY_H
 
-#include <QQuickItem>
 #include <Box2D.h>
+#include <QQuickItem>
 
 class Box2DFixture;
 class Box2DWorld;
@@ -43,6 +43,7 @@ class Box2DWorld;
 class Box2DBody : public QObject, public QQmlParserStatus
 {
     Q_OBJECT
+    QML_ELEMENT
 
     Q_PROPERTY(Box2DWorld *world READ world WRITE setWorld NOTIFY worldChanged)
     Q_PROPERTY(QQuickItem *target READ target WRITE setTarget NOTIFY targetChanged)

--- a/box2dcontact.h
+++ b/box2dcontact.h
@@ -26,14 +26,17 @@
 #ifndef BOX2DCONTACT_H
 #define BOX2DCONTACT_H
 
-#include <QObject>
 #include <Box2D.h>
+#include <QObject>
+#include <QQuickItem>
 
 class Box2DFixture;
 
 class Box2DContact : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
+
     Q_PROPERTY(bool enabled READ isEnabled WRITE setEnabled)
     Q_PROPERTY(Box2DFixture *fixtureA READ fixtureA)
     Q_PROPERTY(Box2DFixture *fixtureB READ fixtureB)
@@ -72,5 +75,7 @@ protected:
     qreal getTangentSpeed() const;
     void setTangentSpeed(qreal speed);
 };
+
+Q_DECLARE_OPAQUE_POINTER(Box2DContact*)
 
 #endif // BOX2DCONTACT_H

--- a/box2ddebugdraw.h
+++ b/box2ddebugdraw.h
@@ -34,6 +34,7 @@ class Box2DWorld;
 class Box2DDebugDraw : public QQuickItem
 {
     Q_OBJECT
+    QML_ELEMENT
 
     Q_PROPERTY(qreal axisScale READ axisScale WRITE setAxisScale NOTIFY axisScaleChanged)
     Q_PROPERTY(DebugFlag flags READ flags WRITE setFlags NOTIFY flagsChanged)

--- a/box2ddistancejoint.h
+++ b/box2ddistancejoint.h
@@ -28,10 +28,13 @@
 
 #include "box2djoint.h"
 #include <Box2D.h>
+#include <QQuickItem>
+
 
 class Box2DDistanceJoint : public Box2DJoint
 {
     Q_OBJECT
+    QML_ELEMENT
 
     Q_PROPERTY(QPointF localAnchorA READ localAnchorA WRITE setLocalAnchorA NOTIFY localAnchorAChanged)
     Q_PROPERTY(QPointF localAnchorB READ localAnchorB WRITE setLocalAnchorB NOTIFY localAnchorBChanged)

--- a/box2dfixture.h
+++ b/box2dfixture.h
@@ -106,12 +106,13 @@ protected:
     b2FixtureDef mFixtureDef;
     Box2DBody *mBody;
 };
-
+Q_DECLARE_OPAQUE_POINTER(Box2DFixture*)
 Q_DECLARE_OPERATORS_FOR_FLAGS(Box2DFixture::CategoryFlags)
 
 class Box2DBox : public Box2DFixture
 {
     Q_OBJECT
+    QML_ELEMENT
 
     Q_PROPERTY(qreal x READ x WRITE setX NOTIFY xChanged)
     Q_PROPERTY(qreal y READ y WRITE setY NOTIFY yChanged)
@@ -164,6 +165,7 @@ private:
 class Box2DCircle : public Box2DFixture
 {
     Q_OBJECT
+    QML_ELEMENT
 
     Q_PROPERTY(qreal x READ x WRITE setX NOTIFY xChanged)
     Q_PROPERTY(qreal y READ y WRITE setY NOTIFY yChanged)
@@ -204,6 +206,7 @@ private:
 class Box2DPolygon : public Box2DFixture
 {
     Q_OBJECT
+    QML_ELEMENT
 
     Q_PROPERTY(QVariantList vertices READ vertices WRITE setVertices NOTIFY verticesChanged)
 
@@ -229,6 +232,7 @@ private:
 class Box2DChain : public Box2DFixture
 {
     Q_OBJECT
+    QML_ELEMENT
 
     Q_PROPERTY(QVariantList vertices READ vertices WRITE setVertices NOTIFY verticesChanged)
     Q_PROPERTY(bool loop READ loop WRITE setLoop NOTIFY loopChanged)
@@ -272,6 +276,7 @@ private:
 class Box2DEdge : public Box2DFixture
 {
     Q_OBJECT
+    QML_ELEMENT
 
     Q_PROPERTY(QVariantList vertices READ vertices WRITE setVertices NOTIFY verticesChanged)
 

--- a/box2dfrictionjoint.h
+++ b/box2dfrictionjoint.h
@@ -28,10 +28,12 @@
 
 #include "box2djoint.h"
 #include <Box2D.h>
+#include <QQuickItem>
 
 class Box2DFrictionJoint : public Box2DJoint
 {
     Q_OBJECT
+    QML_ELEMENT
 
     Q_PROPERTY(QPointF localAnchorA READ localAnchorA WRITE setLocalAnchorA NOTIFY localAnchorAChanged)
     Q_PROPERTY(QPointF localAnchorB READ localAnchorB WRITE setLocalAnchorB NOTIFY localAnchorBChanged)

--- a/box2dgearjoint.h
+++ b/box2dgearjoint.h
@@ -28,10 +28,12 @@
 
 #include "box2djoint.h"
 #include <Box2D.h>
+#include <QQuickItem>
 
 class Box2DGearJoint : public Box2DJoint
 {
     Q_OBJECT
+    QML_ELEMENT
 
     Q_PROPERTY(Box2DJoint *joint1 READ joint1 WRITE setJoint1 NOTIFY joint1Changed)
     Q_PROPERTY(Box2DJoint *joint2 READ joint2 WRITE setJoint2 NOTIFY joint2Changed)

--- a/box2djoint.h
+++ b/box2djoint.h
@@ -113,6 +113,8 @@ private:
     b2Joint *mJoint;
 };
 
+Q_DECLARE_OPAQUE_POINTER(Box2DJoint*)
+
 inline Box2DJoint::JointType Box2DJoint::jointType() const
 {
     return mJointType;

--- a/box2dmotorjoint.h
+++ b/box2dmotorjoint.h
@@ -29,10 +29,12 @@
 
 #include "box2djoint.h"
 #include <Box2D.h>
+#include <QQuickItem>
 
 class Box2DMotorJoint : public Box2DJoint
 {
     Q_OBJECT
+    QML_ELEMENT
 
     Q_PROPERTY(QPointF linearOffset READ linearOffset WRITE setLinearOffset NOTIFY linearOffsetChanged)
     Q_PROPERTY(float angularOffset READ angularOffset WRITE setAngularOffset NOTIFY angularOffsetChanged)

--- a/box2dmousejoint.h
+++ b/box2dmousejoint.h
@@ -28,10 +28,12 @@
 
 #include "box2djoint.h"
 #include <Box2D.h>
+#include <QQuickItem>
 
 class Box2DMouseJoint : public Box2DJoint
 {
     Q_OBJECT
+    QML_ELEMENT
 
     Q_PROPERTY(QPointF target READ target WRITE setTarget NOTIFY targetChanged)
     Q_PROPERTY(float maxForce READ maxForce WRITE setMaxForce NOTIFY maxForceChanged)

--- a/box2dplugin.cpp
+++ b/box2dplugin.cpp
@@ -60,6 +60,7 @@ void Box2DPlugin::registerTypes(const char *uri)
     Q_ASSERT(QLatin1String(uri) == QLatin1String("Box2D"));
 #endif
 
+    // @uri Box2D
     qmlRegisterType<Box2DWorld>(uri, versionMajor, versionMinor, "World");
     qmlRegisterUncreatableType<Box2DProfile>(uri, versionMajor, versionMinor, "Profile",
                                              QStringLiteral("Property group of World"));

--- a/box2dprismaticjoint.h
+++ b/box2dprismaticjoint.h
@@ -28,10 +28,12 @@
 
 #include "box2djoint.h"
 #include <Box2D.h>
+#include <QQuickItem>
 
 class Box2DPrismaticJoint : public Box2DJoint
 {
     Q_OBJECT
+    QML_ELEMENT
 
     Q_PROPERTY(QPointF localAnchorA READ localAnchorA WRITE setLocalAnchorA NOTIFY localAnchorAChanged)
     Q_PROPERTY(QPointF localAnchorB READ localAnchorB WRITE setLocalAnchorB NOTIFY localAnchorBChanged)

--- a/box2dpulleyjoint.h
+++ b/box2dpulleyjoint.h
@@ -28,10 +28,12 @@
 
 #include "box2djoint.h"
 #include <Box2D.h>
+#include <QQuickItem>
 
 class Box2DPulleyJoint : public Box2DJoint
 {
     Q_OBJECT
+    QML_ELEMENT
 
     Q_PROPERTY(QPointF groundAnchorA READ groundAnchorA WRITE setGroundAnchorA NOTIFY groundAnchorAChanged)
     Q_PROPERTY(QPointF groundAnchorB READ groundAnchorB WRITE setGroundAnchorB NOTIFY groundAnchorBChanged)

--- a/box2draycast.h
+++ b/box2draycast.h
@@ -30,12 +30,14 @@
 #include <QPointF>
 
 #include <Box2D.h>
+#include <QQuickItem>
 
 class Box2DFixture;
 
 class Box2DRayCast : public QObject, public b2RayCastCallback
 {
     Q_OBJECT
+    QML_ELEMENT
 
     Q_PROPERTY(float maxFraction READ maxFraction WRITE setMaxFraction)
 

--- a/box2drevolutejoint.h
+++ b/box2drevolutejoint.h
@@ -29,10 +29,12 @@
 
 #include "box2djoint.h"
 #include <Box2D.h>
+#include <QQuickItem>
 
 class Box2DRevoluteJoint : public Box2DJoint
 {
     Q_OBJECT
+    QML_ELEMENT
 
     Q_PROPERTY(QPointF localAnchorA READ localAnchorA WRITE setLocalAnchorA NOTIFY localAnchorAChanged)
     Q_PROPERTY(QPointF localAnchorB READ localAnchorB WRITE setLocalAnchorB NOTIFY localAnchorBChanged)

--- a/box2dropejoint.h
+++ b/box2dropejoint.h
@@ -29,6 +29,7 @@
 
 #include "box2djoint.h"
 #include <Box2D.h>
+#include <QQuickItem>
 
 class b2World;
 class b2RopeJoint;
@@ -36,6 +37,7 @@ class b2RopeJoint;
 class Box2DRopeJoint : public Box2DJoint
 {
     Q_OBJECT
+    QML_ELEMENT
 
     Q_PROPERTY(QPointF localAnchorA READ localAnchorA WRITE setLocalAnchorA NOTIFY localAnchorAChanged)
     Q_PROPERTY(QPointF localAnchorB READ localAnchorB WRITE setLocalAnchorB NOTIFY localAnchorBChanged)

--- a/box2dweldjoint.h
+++ b/box2dweldjoint.h
@@ -28,10 +28,12 @@
 
 #include "box2djoint.h"
 #include <Box2D.h>
+#include <QQuickItem>
 
 class Box2DWeldJoint : public Box2DJoint
 {
     Q_OBJECT
+    QML_ELEMENT
 
     Q_PROPERTY(float referenceAngle READ referenceAngle WRITE setReferenceAngle NOTIFY referenceAngleChanged)
     Q_PROPERTY(float frequencyHz READ frequencyHz WRITE setFrequencyHz NOTIFY frequencyHzChanged)

--- a/box2dwheeljoint.h
+++ b/box2dwheeljoint.h
@@ -29,10 +29,12 @@
 
 #include "box2djoint.h"
 #include <Box2D.h>
+#include <QQuickItem>
 
 class Box2DWheelJoint : public Box2DJoint
 {
     Q_OBJECT
+    QML_ELEMENT
 
     Q_PROPERTY(QPointF localAnchorA READ localAnchorA WRITE setLocalAnchorA NOTIFY localAnchorAChanged)
     Q_PROPERTY(QPointF localAnchorB READ localAnchorB WRITE setLocalAnchorB NOTIFY localAnchorBChanged)

--- a/box2dworld.h
+++ b/box2dworld.h
@@ -33,9 +33,10 @@
 
 #include <Box2D.h>
 
-class Box2DContact;
-class Box2DFixture;
-class Box2DJoint;
+#include "box2dcontact.h"
+#include "box2dfixture.h"
+#include "box2djoint.h"
+
 class Box2DWorld;
 class Box2DRayCast;
 class ContactListener;
@@ -67,6 +68,7 @@ private:
 class Box2DProfile : public QObject
 {
     Q_OBJECT
+    QML_ELEMENT
 
     Q_PROPERTY(float step READ step CONSTANT)
     Q_PROPERTY(float collide READ collide CONSTANT)
@@ -104,6 +106,7 @@ private:
     float mEmitSignals;
 };
 
+Q_DECLARE_OPAQUE_POINTER(Box2DProfile*)
 
 /**
  * Wrapper class around a Box2D world.
@@ -111,6 +114,7 @@ private:
 class Box2DWorld : public QObject, public QQmlParserStatus, b2DestructionListener
 {
     Q_OBJECT
+    QML_ELEMENT
 
     Q_PROPERTY(bool running READ isRunning WRITE setRunning NOTIFY runningChanged)
     Q_PROPERTY(float timeStep READ timeStep WRITE setTimeStep NOTIFY timeStepChanged)


### PR DESCRIPTION
Added `QML_ELEMENT` macros to generate .qmltypes files for QML editor. Also added `// @uri Box2D` hint to disable QML editor warning od Box2D import and set QTP0001 policy for QT6 builds.