### PR TITLE
Add metatypes generation in cmake

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -135,3 +135,28 @@ jobs:
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+  build-windows-cmake-qt6:
+    name: Windows
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v3
+      with:
+        version: '6.5.3'
+        host: 'windows'
+        target: 'desktop'
+        arch: 'win64_mingw'
+        dir: '${{github.workspace}}/qt/'
+        install-deps: 'true'
+
+    - name: Configure CMake
+      env:
+        CMAKE_PREFIX_PATH: ${{env.Qt6_Dir}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -G "MinGW Makefiles"
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,8 +134,10 @@ PRIVATE
 )
 
 get_target_property(have_automoc_prop ${QML_BOX2D_LIBRARY_NAME} AUTOMOC)
+message(STATUS "Have automoc ${have_automoc_prop}")
 if("${QT_VERSION}" VERSION_GREATER_EQUAL "6.2.0" AND "${have_automoc_prop}")
   qt_extract_metatypes(${QML_BOX2D_LIBRARY_NAME})
+  message(STATUS "qt_extract_metatypes(${QML_BOX2D_LIBRARY_NAME})")
 endif()
 
 if(MINGW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,14 +45,16 @@ set(QT_MAJOR_VERSION Qt6)
 
 if(USE_QT6)
   find_package(Qt6 6.2 COMPONENTS Quick Core Qml)
+  set(QT_VERSION ${Qt6_VERSION})
 endif()
 
 if(NOT Qt6_FOUND)
     find_package(Qt5 5.12 COMPONENTS Quick Core Qml REQUIRED)
     set(QT_MAJOR_VERSION Qt5)
+    set(QT_VERSION ${Qt5_VERSION})
 endif()
 
-message(STATUS "Using ${QT_MAJOR_VERSION}")
+message(STATUS "Using ${QT_MAJOR_VERSION} (${QT_VERSION})")
 
 if(BUILD_SHARED_LIBS)
   set(QML_PLUGIN_LINK_TYPE SHARED)
@@ -130,6 +132,11 @@ target_compile_definitions(${QML_BOX2D_LIBRARY_NAME}
 PRIVATE
     $<$<STREQUAL:${QML_PLUGIN_LINK_TYPE},STATIC>:QT_STATICPLUGIN>
 )
+
+get_target_property(have_automoc_prop ${QML_BOX2D_LIBRARY_NAME} AUTOMOC)
+if("${QT_VERSION}" VERSION_GREATER_EQUAL "6.2.0" AND "${have_automoc_prop}")
+  qt_extract_metatypes(${QML_BOX2D_LIBRARY_NAME})
+endif()
 
 if(MINGW)
   # Remove lib prefix when compiling with mingw on Windows to have the same library name as in qmldir


### PR DESCRIPTION
At least on Windows, with Qt6.5.3, it is needed.

I followed documentation in https://www.qt.io/blog/compiling-qml-to-c-making-types-visible