### PR TITLE
add policy for Qt > 6.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,12 @@ if(USE_QT6)
   find_package(Qt6 6.2 COMPONENTS Quick Core Qml)
 endif()
 
-if(NOT Qt6_FOUND)
+if(Qt6_FOUND)
+  # Set Qt policy, introduced in Qt6.5
+  if(QT_KNOWN_POLICY_QTP0001)
+    qt6_policy(SET QTP0001 NEW)
+  endif()
+else()
     find_package(Qt5 5.12 COMPONENTS Quick Core Qml REQUIRED)
     set(QT_MAJOR_VERSION Qt5)
 endif()


### PR DESCRIPTION
IPO makes not a lot of sense for a library so I've removed it.

Qt added a policy in Qt6.5: https://doc.qt.io/qt-6/qt-cmake-policy-qtp0001.html, this PR enables it by default.